### PR TITLE
Add export SSH key modal and improve server dialog

### DIFF
--- a/src/ui/modal/add_server.rs
+++ b/src/ui/modal/add_server.rs
@@ -1,1 +1,292 @@
+use gtk4::{prelude::*, Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject};
+use crate::service::ssh_keys::load_ssh_keys;
+use dirs;
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
 
+pub fn create_add_server_dialog(
+    on_save: Option<std::boxed::Box<dyn Fn() + 'static>>,
+) -> Dialog {
+    let dialog = Dialog::builder()
+        .title("Add Server")
+        .build();
+
+    let content_box = Box::new(Orientation::Vertical, 12);
+    content_box.set_margin_top(20);
+    content_box.set_margin_bottom(20);
+    content_box.set_margin_start(24);
+    content_box.set_margin_end(24);
+
+    let header_bar = HeaderBar::new();
+    header_bar.set_title_widget(Some(&Label::new(Some("Add Server"))));
+    dialog.set_titlebar(Some(&header_bar));
+
+    let name_input = Entry::builder()
+        .placeholder_text("Name")
+        .primary_icon_name("edit-symbolic")
+        .build();
+    content_box.append(&name_input);
+
+    let ip_input = Entry::builder()
+        .placeholder_text("IP")
+        .primary_icon_name("network-server-symbolic")
+        .build();
+    content_box.append(&ip_input);
+
+    let user_input = Entry::builder()
+        .placeholder_text("User")
+        .primary_icon_name("avatar-default-symbolic")
+        .build();
+    content_box.append(&user_input);
+
+    let port_input = Entry::builder()
+        .placeholder_text("Port")
+        .text("22")
+        .primary_icon_name("network-wired-symbolic")
+        .build();
+    content_box.append(&port_input);
+
+    let ssh_key_label = Label::new(Some("SSH Key:"));
+    ssh_key_label.set_halign(gtk4::Align::Start);
+    content_box.append(&ssh_key_label);
+    
+    let ssh_key_dropdown = DropDown::new(None::<StringList>, None::<&gtk4::Expression>);
+    
+    let ssh_keys = match load_ssh_keys() {
+        Ok(keys) => keys,
+        Err(_e) => {
+            vec![]
+        }
+    };
+
+    let key_list = StringList::new(&[]);
+    let mut key_names = vec!["None".to_string()];
+    
+    key_list.append("None");
+    for key in &ssh_keys {
+        key_list.append(&key.name);
+        key_names.push(key.name.clone());
+    }
+    
+    ssh_key_dropdown.set_model(Some(&key_list));
+    ssh_key_dropdown.set_selected(0);
+    
+    ssh_key_dropdown.connect_selected_notify({
+        let _ssh_key_dropdown = ssh_key_dropdown.clone();
+        move |_| {}
+    });
+    
+    content_box.append(&ssh_key_dropdown);
+
+        let cancel_button = Button::builder()
+        .label("Cancel")
+        .css_classes(
+            vec!["destructive-action"]
+        )
+        .build();
+
+    let export_key_button = Button::builder()
+        .label("Export Key")
+        .css_classes(vec!["flat"])
+        .build();
+
+    let save_button = Button::builder()
+        .label("Save")
+        .css_classes(vec!["suggested-action"])
+        .build();
+    save_button.set_sensitive(false);
+
+    let button_box = Box::new(Orientation::Horizontal, 12);
+    button_box.set_halign(gtk4::Align::End);
+    button_box.append(&export_key_button);
+    button_box.append(&cancel_button);
+    button_box.append(&save_button);
+    content_box.append(&button_box);
+
+    dialog.set_child(Some(&content_box));
+
+    {
+        let dialog = dialog.clone();
+        cancel_button.connect_clicked(move |_| {
+            dialog.close();
+        });
+    }
+
+    let dialog_clone_export = dialog.clone();
+    let ip_input_clone = ip_input.clone();
+    let user_input_clone = user_input.clone();
+    let ssh_drop_clone = ssh_key_dropdown.clone();
+
+    export_key_button.connect_clicked(move |_| {
+        let host = ip_input_clone.text();
+        let user = user_input_clone.text();
+        let selected = ssh_drop_clone.selected();
+        if selected == 0 {
+            return;
+        }
+        let key_name = ssh_drop_clone
+            .model()
+            .and_then(|m| m.item(selected))
+            .and_then(|obj| obj.downcast::<StringObject>().ok())
+            .map(|o| o.string())
+            .unwrap_or_default();
+
+        let pub_key_path = format!(
+            "{}/.ssh/{}.pub",
+            dirs::home_dir().unwrap().display(),
+            key_name
+        );
+        let export_dialog = crate::ui::modal::export_key::create_export_key_dialog(
+            &dialog_clone_export,
+            &user,
+            &host,
+            &pub_key_path,
+        );
+        export_dialog.present();
+    });
+
+    let update_state = Rc::new({
+        let name_input = name_input.clone();
+        let ip_input = ip_input.clone();
+        let user_input = user_input.clone();
+        let save_button = save_button.clone();
+        let ssh_key_dropdown = ssh_key_dropdown.clone();
+        move || {
+            let name_ok = !name_input.text().trim().is_empty();
+            let ip_ok = !ip_input.text().trim().is_empty();
+            let user_ok = !user_input.text().trim().is_empty();
+            let key_ok = ssh_key_dropdown.selected() > 0;
+            let enable = name_ok && ip_ok && user_ok && key_ok;
+            save_button.set_sensitive(enable);
+        }
+    });
+
+    {
+        let update_state = Rc::clone(&update_state);
+        name_input.connect_changed(move |_| {
+            update_state();
+        });
+    }
+    {
+        let update_state = Rc::clone(&update_state);
+        ip_input.connect_changed(move |_| {
+            update_state();
+        });
+    }
+    {
+        let update_state = Rc::clone(&update_state);
+        user_input.connect_changed(move |_| {
+            update_state();
+        });
+    }
+    {
+        let update_state = Rc::clone(&update_state);
+        let ssh_key_dropdown = ssh_key_dropdown.clone();
+        ssh_key_dropdown.connect_selected_notify(move |_| {
+            update_state();
+        });
+    }
+    update_state();
+
+    save_button.connect_clicked({
+        let dialog = dialog.clone();
+        let name_input = name_input.clone();
+        let ip_input = ip_input.clone();
+        let user_input = user_input.clone();
+        let port_input = port_input.clone();
+        let ssh_key_dropdown = ssh_key_dropdown.clone();
+        let ssh_keys = ssh_keys.clone();
+        move |_| {
+            let name = name_input.text().trim().to_string();
+            let hostname = ip_input.text().trim().to_string();
+            let user = user_input.text().trim().to_string();
+            let port = port_input.text().trim().to_string();
+
+            if name.is_empty() || hostname.is_empty() || user.is_empty() { return; }
+
+            let selected_index = ssh_key_dropdown.selected();
+            let selected_key_name = if selected_index > 0 {
+                let key_index = (selected_index - 1) as usize;
+                if key_index < ssh_keys.len() { Some(ssh_keys[key_index].name.clone()) } else { None }
+            } else {
+                None
+            };
+
+            let ssh_dir = dirs::home_dir().unwrap_or_default().join(".ssh");
+            let config_path: PathBuf = ssh_dir.join("config");
+
+            if !ssh_dir.exists() {
+                if let Err(e) = fs::create_dir_all(&ssh_dir) {
+                    eprintln!("Failed to create ~/.ssh directory: {}", e);
+                    return;
+                }
+            }
+
+            if !config_path.exists() {
+                if let Err(e) = fs::write(&config_path, "") {
+                    eprintln!("Failed to create ~/.ssh/config: {}", e);
+                    return;
+                }
+            }
+
+            let existing = match fs::read_to_string(&config_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Failed to read ~/.ssh/config: {}", e);
+                    return;
+                }
+            };
+
+            let mut lines: Vec<String> = existing.lines().map(|s| s.to_string()).collect();
+
+            let mut new_section: Vec<String> = Vec::new();
+            new_section.push(format!("Host {}", name));
+            new_section.push(format!("  HostName {}", hostname));
+            new_section.push(format!("  User {}", user));
+            if !port.is_empty() && port != "22" { new_section.push(format!("  Port {}", port)); }
+            if let Some(key_name) = selected_key_name.as_ref() {
+                new_section.push(format!("  IdentityFile ~/.ssh/{}", key_name));
+            }
+
+            let mut section_start: Option<usize> = None;
+            let mut section_end: usize = lines.len();
+            for (i, line) in lines.iter().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("Host ") {
+                    let host_val = trimmed.strip_prefix("Host ").unwrap_or("");
+                    if section_start.is_none() && host_val == name {
+                        section_start = Some(i);
+                    } else if section_start.is_some() {
+                        section_end = i;
+                        break;
+                    }
+                }
+            }
+
+            if let Some(start) = section_start {
+                lines.splice(start..section_end, new_section);
+            } else {
+                if !lines.is_empty() && !existing.ends_with('\n') {
+                    lines.push(String::new());
+                }
+                lines.extend(new_section);
+                lines.push(String::new());
+            }
+
+            let new_content = lines.join("\n");
+            if let Err(e) = fs::write(&config_path, new_content) {
+                eprintln!("Failed to write ~/.ssh/config: {}", e);
+                return;
+            }
+
+
+            if let Some(cb) = &on_save {
+                cb();
+            }
+            dialog.close();
+        }
+    });
+
+    dialog
+}

--- a/src/ui/modal/add_server.rs
+++ b/src/ui/modal/add_server.rs
@@ -1,7 +1,8 @@
 use crate::service::ssh_keys::load_ssh_keys;
 use dirs;
 use gtk4::{
-    Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject, prelude::*,
+    Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject, 
+    prelude::*,
 };
 use std::fs;
 use std::path::PathBuf;

--- a/src/ui/modal/add_server.rs
+++ b/src/ui/modal/add_server.rs
@@ -1,16 +1,15 @@
-use gtk4::{prelude::*, Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject};
 use crate::service::ssh_keys::load_ssh_keys;
 use dirs;
+use gtk4::{
+    prelude::*, Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList,
+    StringObject,
+};
 use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-pub fn create_add_server_dialog(
-    on_save: Option<std::boxed::Box<dyn Fn() + 'static>>,
-) -> Dialog {
-    let dialog = Dialog::builder()
-        .title("Add Server")
-        .build();
+pub fn create_add_server_dialog(on_save: Option<std::boxed::Box<dyn Fn() + 'static>>) -> Dialog {
+    let dialog = Dialog::builder().title("Add Server").build();
 
     let content_box = Box::new(Orientation::Vertical, 12);
     content_box.set_margin_top(20);
@@ -50,9 +49,9 @@ pub fn create_add_server_dialog(
     let ssh_key_label = Label::new(Some("SSH Key:"));
     ssh_key_label.set_halign(gtk4::Align::Start);
     content_box.append(&ssh_key_label);
-    
+
     let ssh_key_dropdown = DropDown::new(None::<StringList>, None::<&gtk4::Expression>);
-    
+
     let ssh_keys = match load_ssh_keys() {
         Ok(keys) => keys,
         Err(_e) => {
@@ -62,28 +61,26 @@ pub fn create_add_server_dialog(
 
     let key_list = StringList::new(&[]);
     let mut key_names = vec!["None".to_string()];
-    
+
     key_list.append("None");
     for key in &ssh_keys {
         key_list.append(&key.name);
         key_names.push(key.name.clone());
     }
-    
+
     ssh_key_dropdown.set_model(Some(&key_list));
     ssh_key_dropdown.set_selected(0);
-    
+
     ssh_key_dropdown.connect_selected_notify({
         let _ssh_key_dropdown = ssh_key_dropdown.clone();
         move |_| {}
     });
-    
+
     content_box.append(&ssh_key_dropdown);
 
-        let cancel_button = Button::builder()
+    let cancel_button = Button::builder()
         .label("Cancel")
-        .css_classes(
-            vec!["destructive-action"]
-        )
+        .css_classes(vec!["destructive-action"])
         .build();
 
     let export_key_button = Button::builder()
@@ -203,12 +200,18 @@ pub fn create_add_server_dialog(
             let user = user_input.text().trim().to_string();
             let port = port_input.text().trim().to_string();
 
-            if name.is_empty() || hostname.is_empty() || user.is_empty() { return; }
+            if name.is_empty() || hostname.is_empty() || user.is_empty() {
+                return;
+            }
 
             let selected_index = ssh_key_dropdown.selected();
             let selected_key_name = if selected_index > 0 {
                 let key_index = (selected_index - 1) as usize;
-                if key_index < ssh_keys.len() { Some(ssh_keys[key_index].name.clone()) } else { None }
+                if key_index < ssh_keys.len() {
+                    Some(ssh_keys[key_index].name.clone())
+                } else {
+                    None
+                }
             } else {
                 None
             };
@@ -244,7 +247,9 @@ pub fn create_add_server_dialog(
             new_section.push(format!("Host {}", name));
             new_section.push(format!("  HostName {}", hostname));
             new_section.push(format!("  User {}", user));
-            if !port.is_empty() && port != "22" { new_section.push(format!("  Port {}", port)); }
+            if !port.is_empty() && port != "22" {
+                new_section.push(format!("  Port {}", port));
+            }
             if let Some(key_name) = selected_key_name.as_ref() {
                 new_section.push(format!("  IdentityFile ~/.ssh/{}", key_name));
             }
@@ -279,7 +284,6 @@ pub fn create_add_server_dialog(
                 eprintln!("Failed to write ~/.ssh/config: {}", e);
                 return;
             }
-
 
             if let Some(cb) = &on_save {
                 cb();

--- a/src/ui/modal/add_server.rs
+++ b/src/ui/modal/add_server.rs
@@ -1,8 +1,7 @@
 use crate::service::ssh_keys::load_ssh_keys;
 use dirs;
 use gtk4::{
-    prelude::*, Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList,
-    StringObject,
+    Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject, prelude::*,
 };
 use std::fs;
 use std::path::PathBuf;

--- a/src/ui/modal/add_server.rs
+++ b/src/ui/modal/add_server.rs
@@ -1,7 +1,7 @@
 use crate::service::ssh_keys::load_ssh_keys;
 use dirs;
 use gtk4::{
-    Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject, 
+    Box, Button, Dialog, DropDown, Entry, HeaderBar, Label, Orientation, StringList, StringObject,
     prelude::*,
 };
 use std::fs;

--- a/src/ui/modal/export_key.rs
+++ b/src/ui/modal/export_key.rs
@@ -1,7 +1,7 @@
 use gtk4::glib::{self, ControlFlow};
-use gtk4::{prelude::*, Box, Button, Dialog, Entry, HeaderBar, Label, Orientation, Spinner};
+use gtk4::{Box, Button, Dialog, Entry, HeaderBar, Label, Orientation, Spinner, prelude::*};
 use std::process::Command;
-use std::sync::mpsc::{channel, TryRecvError};
+use std::sync::mpsc::{TryRecvError, channel};
 use std::thread;
 
 pub fn create_export_key_dialog(

--- a/src/ui/modal/export_key.rs
+++ b/src/ui/modal/export_key.rs
@@ -1,0 +1,154 @@
+use gtk4::{prelude::*, Box, Button, Dialog, Entry, HeaderBar, Label, Orientation, Spinner};
+use gtk4::glib::{self, ControlFlow};
+use std::process::Command;
+use std::thread;
+use std::sync::mpsc::{channel, TryRecvError};
+
+pub fn create_export_key_dialog(parent: &Dialog, user: &str, host: &str, pub_key_path: &str) -> Dialog {
+    let dialog = Dialog::builder()
+        .transient_for(parent)
+        .modal(true)
+        .title("Export SSH Key")
+        .build();
+
+    let header = HeaderBar::new();
+    header.set_title_widget(Some(&Label::new(Some("Export SSH Key"))));
+    dialog.set_titlebar(Some(&header));
+
+    let vbox = Box::new(Orientation::Vertical, 12);
+    vbox.set_margin_top(24);
+    vbox.set_margin_bottom(24);
+    vbox.set_margin_start(24);
+    vbox.set_margin_end(24);
+
+    let pass_entry = Entry::builder()
+        .placeholder_text("Password")
+        .visibility(false)
+        .primary_icon_name("dialog-password-symbolic")
+        .build();
+    vbox.append(&pass_entry);
+
+    let status_label = Label::new(Some(""));
+    status_label.set_visible(false);
+    vbox.append(&status_label);
+
+    let spinner = Spinner::new();
+    spinner.set_visible(false);
+    vbox.append(&spinner);
+
+    let cancel_btn = Button::with_label("Cancel");
+    let export_btn = Button::with_label("Export");
+    export_btn.add_css_class("suggested-action");
+
+    let hbox = Box::new(Orientation::Horizontal, 12);
+    hbox.set_halign(gtk4::Align::End);
+    hbox.append(&cancel_btn);
+    hbox.append(&export_btn);
+    vbox.append(&hbox);
+
+    dialog.set_child(Some(&vbox));
+
+    let dialog_clone1 = dialog.clone();
+    cancel_btn.connect_clicked(move |_| {
+        dialog_clone1.close();
+    });
+    let user = user.to_string();
+    let host = host.to_string();
+    let pub_key_path = pub_key_path.to_string();
+    let pass_entry_clone = pass_entry.clone();
+    let export_btn_clone = export_btn.clone();
+    let cancel_btn_clone = cancel_btn.clone();
+    let status_label_clone = status_label.clone();
+    let spinner_clone = spinner.clone();
+    let dialog_final = dialog.clone();
+    
+    export_btn.connect_clicked(move |_| {
+        let password = pass_entry_clone.text().to_string();
+        if password.is_empty() { return; }
+
+        pass_entry_clone.set_sensitive(false);
+        export_btn_clone.set_sensitive(false);
+        cancel_btn_clone.set_sensitive(false);
+        status_label_clone.set_text("Exporting SSH key...");
+        status_label_clone.set_visible(true);
+        spinner_clone.start();
+        spinner_clone.set_visible(true);
+
+        let (tx, rx) = channel::<Result<(), String>>();
+        let pub_key_path_bg = pub_key_path.clone();
+        let user_bg = user.clone();
+        let host_bg = host.clone();
+        thread::spawn(move || {
+            let status = Command::new("sshpass")
+                .args([
+                    "-p",
+                    &password,
+                    "ssh-copy-id",
+                    "-i",
+                    &pub_key_path_bg,
+                    &format!("{}@{}", user_bg, host_bg),
+                ])
+                .status();
+
+            let result = match status {
+                Ok(s) if s.success() => Ok(()),
+                Ok(_s) => Err("Invalid credentials or connection failed".to_string()),
+                Err(e) => Err(format!("Connection error - {}", e)),
+            };
+
+            let _ = tx.send(result);
+        });
+
+        let status_label_ui = status_label_clone.clone();
+        let spinner_ui = spinner_clone.clone();
+        let export_btn_ui = export_btn_clone.clone();
+        let dialog_ui = dialog_final.clone();
+        glib::idle_add_local(move || {
+            match rx.try_recv() {
+                Ok(result) => {
+                    spinner_ui.stop();
+                    spinner_ui.set_visible(false);
+
+                    match result {
+                        Ok(()) => {
+                            status_label_ui.set_text("✓ SSH key exported successfully!");
+                            status_label_ui.add_css_class("success");
+                        }
+                        Err(msg) => {
+                            status_label_ui.set_text(&format!("✗ {}", msg));
+                            status_label_ui.add_css_class("error");
+                        }
+                    }
+
+                    export_btn_ui.set_label("Close");
+                    export_btn_ui.set_sensitive(true);
+
+                    let dialog_close = dialog_ui.clone();
+                    export_btn_ui.connect_clicked(move |_| {
+                        dialog_close.close();
+                    });
+
+                    ControlFlow::Break
+                }
+                Err(TryRecvError::Empty) => ControlFlow::Continue,
+                Err(TryRecvError::Disconnected) => {
+                    spinner_ui.stop();
+                    spinner_ui.set_visible(false);
+                    status_label_ui.set_text("✗ Internal error - worker disconnected");
+                    status_label_ui.add_css_class("error");
+                    export_btn_ui.set_label("Close");
+                    export_btn_ui.set_sensitive(true);
+
+                    let dialog_close = dialog_ui.clone();
+                    export_btn_ui.connect_clicked(move |_| {
+                        dialog_close.close();
+                    });
+
+                    ControlFlow::Break
+                }
+            }
+        });
+    });
+
+    dialog
+}

--- a/src/ui/modal/mod.rs
+++ b/src/ui/modal/mod.rs
@@ -2,4 +2,5 @@ pub mod about;
 pub mod add_server;
 pub mod delete_key;
 pub mod edit_server;
+pub mod export_key;
 pub mod info_key;

--- a/src/ui/tab/server.rs
+++ b/src/ui/tab/server.rs
@@ -1,4 +1,4 @@
-use crate::service::{SshServer, load_ssh_servers};
+use crate::service::{load_ssh_servers, SshServer};
 use crate::ui::component::create_server_card;
 use crate::ui::component::icon_button::create_icon_button;
 use gtk4::prelude::*;
@@ -42,9 +42,13 @@ pub fn create_server_tab(
         create_icon_button("New Host", "network-server-symbolic", 100, 30, move || {
             if let Some(window) = &parent_window_clone {
                 let cb_storage = Rc::clone(&refresh_fn_storage_btn);
-                let add_server_dialog = crate::ui::modal::add_server::create_add_server_dialog(Some(std::boxed::Box::new(move || {
-                    if let Some(cb) = &*cb_storage.borrow() { cb(); }
-                })));
+                let add_server_dialog = crate::ui::modal::add_server::create_add_server_dialog(
+                    Some(std::boxed::Box::new(move || {
+                        if let Some(cb) = &*cb_storage.borrow() {
+                            cb();
+                        }
+                    })),
+                );
                 add_server_dialog.set_transient_for(Some(window));
                 add_server_dialog.show();
             }
@@ -52,14 +56,10 @@ pub fn create_server_tab(
     };
 
     let terminal_button =
-        create_icon_button("Terminal", "utilities-terminal-symbolic", 100, 30, || {
-            println!("Terminal demandé")
-        });
+        create_icon_button("Terminal", "utilities-terminal-symbolic", 100, 30, || {});
     terminal_button.set_sensitive(false);
 
-    let serial_button = create_icon_button("Serial", "network-wired-symbolic", 100, 30, || {
-        println!("Connexion série demandée")
-    });
+    let serial_button = create_icon_button("Serial", "network-wired-symbolic", 100, 30, || {});
     serial_button.set_sensitive(false);
 
     buttons_container.append(&new_host_button);
@@ -98,7 +98,6 @@ pub fn create_server_tab(
 
     let servers_data = Rc::new(RefCell::new(all_servers));
     let server_cards = Rc::new(RefCell::new(Vec::new()));
-    let refresh_fn_storage = Rc::new(RefCell::new(None::<Rc<dyn Fn()>>));
 
     let create_server_cards = {
         let servers_data = Rc::clone(&servers_data);
@@ -107,18 +106,13 @@ pub fn create_server_tab(
         let parent_window_clone = parent_window.cloned();
         let refresh_fn_storage = Rc::clone(&refresh_fn_storage);
         Rc::new(move |filter: &str, _refresh_fn: Option<&Rc<dyn Fn()>>| {
-            println!("create_server_cards called with filter: '{}'", filter);
             while let Some(child) = servers_grid.first_child() {
                 servers_grid.remove(&child);
             }
             server_cards.borrow_mut().clear();
 
-            println!("Reloading SSH servers from config...");
             let updated_servers = match crate::service::load_ssh_servers() {
-                Ok(servers) => {
-                    println!("Loaded {} servers from config", servers.len());
-                    servers
-                }
+                Ok(servers) => servers,
                 Err(e) => {
                     eprintln!("Erreur lors du rechargement des serveurs: {}", e);
                     servers_data.borrow().clone()
@@ -191,9 +185,7 @@ pub fn create_server_tab(
         let search_entry = search_entry.clone();
         let create_server_cards = Rc::clone(&create_server_cards);
         move || {
-            println!("Refresh function called!");
             let text = search_entry.text();
-            println!("Current search text: '{}'", text);
             create_server_cards(&text, None);
         }
     });

--- a/src/ui/tab/server.rs
+++ b/src/ui/tab/server.rs
@@ -1,4 +1,4 @@
-use crate::service::{load_ssh_servers, SshServer};
+use crate::service::{SshServer, load_ssh_servers};
 use crate::ui::component::create_server_card;
 use crate::ui::component::icon_button::create_icon_button;
 use gtk4::prelude::*;

--- a/src/ui/tab/server.rs
+++ b/src/ui/tab/server.rs
@@ -34,10 +34,22 @@ pub fn create_server_tab(
     buttons_container.set_halign(gtk4::Align::Start);
     buttons_container.set_hexpand(true);
 
-    let new_host_button =
-        create_icon_button("New Host", "network-server-symbolic", 100, 30, || {
-            println!("Nouveau serveur demandé")
-        });
+    let refresh_fn_storage = Rc::new(RefCell::new(None::<Rc<dyn Fn()>>));
+
+    let new_host_button = {
+        let parent_window_clone = parent_window.cloned();
+        let refresh_fn_storage_btn = Rc::clone(&refresh_fn_storage);
+        create_icon_button("New Host", "network-server-symbolic", 100, 30, move || {
+            if let Some(window) = &parent_window_clone {
+                let cb_storage = Rc::clone(&refresh_fn_storage_btn);
+                let add_server_dialog = crate::ui::modal::add_server::create_add_server_dialog(Some(std::boxed::Box::new(move || {
+                    if let Some(cb) = &*cb_storage.borrow() { cb(); }
+                })));
+                add_server_dialog.set_transient_for(Some(window));
+                add_server_dialog.show();
+            }
+        })
+    };
 
     let terminal_button =
         create_icon_button("Terminal", "utilities-terminal-symbolic", 100, 30, || {


### PR DESCRIPTION
Introduces a new export_key modal for exporting SSH keys to remote servers. Enhances the add_server dialog with SSH key selection and export functionality, and updates the server tab to use the new dialog and refresh callback after adding a server.