### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: Check PR
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Cleboost/Rustmius/security/code-scanning/1](https://github.com/Cleboost/Rustmius/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, restricting the `GITHUB_TOKEN` permissions to the minimal required level. For this workflow, the steps involved (checking out code, installing dependencies, building, formatting checks) only require read access to repository contents. Therefore, the best way to fix the problem is to add `permissions: contents: read` at either the workflow root (applies to all jobs) or inside the `check` job (applies only to that job). The standard and recommended practice is to add it at the workflow root for clarity and safety unless some jobs require different permissions.

This change should be made near the top of the file, after the `name:` and before or after the `on:` key. No additional imports or dependencies are required; this is a configuration fix. Existing functionality will be unchanged but safer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
