### PR TITLE
Add folder and server layout management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "1158f326d7b755a9ae2b36c5b5391400e3431f3b77418cedb6d7130126628f10"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
- "glib",
+ "glib 0.21.1",
  "libc",
 ]
 
@@ -86,9 +86,9 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b963177900ec8e783927e5ed99e16c0ec1b723f1f125dff8992db28ef35c62c3"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.21.1",
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -103,12 +103,22 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d458d63f0f0f482c8da9b7c8b76c21bd885a02056cc94c6404d861ca2b8206"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
@@ -323,7 +333,7 @@ checksum = "3c7330cdbbc653df431331ae3d9d59e985a0fecaf33d74c7c1c5d13ab0245f6c"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
- "glib",
+ "glib 0.21.1",
  "libc",
 ]
 
@@ -333,11 +343,11 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25899cc931dc28cba912ebec793b730f53d2d419f90a562fcb29b53bd10aa82"
 dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.21.1",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -350,7 +360,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk4-sys",
  "gio",
- "glib",
+ "glib 0.21.1",
  "libc",
  "pango",
 ]
@@ -363,13 +373,13 @@ checksum = "2edbda0d879eb85317bdb49a3da591ed70a804a10776e358ef416be38c6db2c5"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.21.1",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -411,11 +421,24 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "gio-sys",
- "glib",
+ "gio-sys 0.21.1",
+ "glib 0.21.1",
  "libc",
  "pin-project-lite",
  "smallvec",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef"
+dependencies = [
+ "glib-sys 0.19.8",
+ "gobject-sys 0.19.8",
+ "libc",
+ "system-deps 6.2.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -424,11 +447,33 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a03f2234671e5a588cfe1f59c2b22c103f5772ea351be9cc824a9ce0d06d99fd"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "glib"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys 0.19.8",
+ "glib-macros 0.19.9",
+ "glib-sys 0.19.8",
+ "gobject-sys 0.19.8",
+ "libc",
+ "memchr",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -443,13 +488,26 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.21.1",
+ "glib-macros 0.21.0",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "libc",
  "memchr",
  "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -467,12 +525,33 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5"
+dependencies = [
+ "libc",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "glib-sys"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc7c43cff6a7dc43821e45ebf172399437acd6716fa2186b6852d2b397bf622d"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e"
+dependencies = [
+ "glib-sys 0.19.8",
+ "libc",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -481,9 +560,9 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9a190eef2bce144a6aa8434e306974c6062c398e0a33a146d60238f9062d5c"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.21.1",
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -492,7 +571,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96914394464c04df8279c23976293afd53b2588e03c9d8d9662ef6528654a85"
 dependencies = [
- "glib",
+ "glib 0.21.1",
  "graphene-sys",
  "libc",
 ]
@@ -503,10 +582,10 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8205bb19b7a041cf059be3c94d6b23b3f2c6c96362c44311dcf184e4a9422a"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.21.1",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -517,7 +596,7 @@ checksum = "d5dbe33ceed6fc20def67c03d36e532f5a4a569ae437ae015a7146094f31e10c"
 dependencies = [
  "cairo-rs",
  "gdk4",
- "glib",
+ "glib 0.21.1",
  "graphene-rs",
  "gsk4-sys",
  "libc",
@@ -532,12 +611,12 @@ checksum = "8d76011d55dd19fde16ffdedee08877ae6ec942818cfa7bc08a91259bc0b9fc9"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "graphene-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -552,7 +631,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk4",
  "gio",
- "glib",
+ "glib 0.21.1",
  "graphene-rs",
  "gsk4",
  "gtk4-macros",
@@ -582,14 +661,14 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk4-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.21.1",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "graphene-sys",
  "gsk4-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -920,7 +999,7 @@ checksum = "4df6715d1257bd8c093295b77a276ed129d73543b10304fec5829ced5d5b7c41"
 dependencies = [
  "gdk4",
  "gio",
- "glib",
+ "glib 0.21.1",
  "gtk4",
  "libadwaita-sys",
  "libc",
@@ -934,13 +1013,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf8950090cc180250cdb1ff859a39748feeda7a53a9f28ead3a17a14cc37ae2"
 dependencies = [
  "gdk4-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.21.1",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "gtk4-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -1107,7 +1186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab47feb3403aa564edaeb68620c5b9159f8814733a7dd45f0b1a27d19de362fe"
 dependencies = [
  "gio",
- "glib",
+ "glib 0.21.1",
  "libc",
  "pango-sys",
 ]
@@ -1118,10 +1197,10 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f855bccb447644e149fae79086e1f81514c30fe5e9b8bd257d9d3c941116c86"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.21.1",
+ "gobject-sys 0.21.1",
  "libc",
- "system-deps",
+ "system-deps 7.0.5",
 ]
 
 [[package]]
@@ -1158,6 +1237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1279,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,7 +1315,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1324,12 +1441,14 @@ version = "0.2.0"
 dependencies = [
  "base64",
  "dirs",
+ "glib 0.19.9",
  "gtk4",
  "html-escape",
  "libadwaita",
  "reqwest",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1539,16 +1658,35 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.5"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck",
  "pkg-config",
  "toml",
  "version-compare",
 ]
+
+[[package]]
+name = "system-deps"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb"
+dependencies = [
+ "cfg-expr 0.20.2",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"
@@ -1571,11 +1709,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1788,6 +1946,19 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "rand",
+ "serde",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2091,6 +2262,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2024"
 [dependencies]
 libadwaita = { version = "0.8", features = ["v1_7"] }
 gtk4 = "0.10.0"
+glib = "0.19"
 dirs = "6.0"
 base64 = "0.22"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 html-escape = "0.2"
+uuid = { version = "1.8", features = ["v4", "fast-rng", "serde"] }

--- a/src/service/layout.rs
+++ b/src/service/layout.rs
@@ -1,0 +1,694 @@
+use crate::service::SshServer;
+use dirs::config_dir;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum LayoutItem {
+    Server {
+        name: String,
+    },
+    Folder {
+        #[serde(default)]
+        id: String,
+        name: String,
+        items: Vec<LayoutItem>,
+    },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Layout {
+    pub items: Vec<LayoutItem>,
+}
+
+fn layout_config_path_internal() -> PathBuf {
+    let base = config_dir().unwrap_or_else(|| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        Path::new(&home).join(".config")
+    });
+    base.join("rustmius").join("layout.json")
+}
+
+pub fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+pub fn load_layout(existing_servers: &[SshServer]) -> Layout {
+    let path = layout_config_path_internal();
+    let mut layout: Layout = match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => Layout::default(),
+    };
+    ensure_folder_ids(&mut layout);
+    sync_layout_with_servers(&mut layout, existing_servers);
+    layout
+}
+
+fn ensure_folder_ids(layout: &mut Layout) {
+    fn ensure_in_items(items: &mut [LayoutItem]) {
+        for item in items.iter_mut() {
+            if let LayoutItem::Folder { id, items, .. } = item {
+                if id.is_empty() {
+                    *id = Uuid::new_v4().to_string();
+                }
+                ensure_in_items(items);
+            }
+        }
+    }
+    ensure_in_items(&mut layout.items);
+}
+
+pub fn save_layout(layout: &Layout) -> Result<(), Box<dyn Error>> {
+    let path = layout_config_path_internal();
+    ensure_parent_dir(&path)?;
+    let content = serde_json::to_string_pretty(layout)?;
+    fs::write(path, content)?;
+    Ok(())
+}
+
+fn collect_server_names(item: &LayoutItem) -> Vec<String> {
+    match item {
+        LayoutItem::Server { name } => vec![name.clone()],
+        LayoutItem::Folder { items, .. } => {
+            let mut names = Vec::new();
+            for sub_item in items {
+                names.extend(collect_server_names(sub_item));
+            }
+            names
+        }
+    }
+}
+
+pub fn sync_layout_with_servers(layout: &mut Layout, existing_servers: &[SshServer]) {
+    let mut known: Vec<String> = Vec::new();
+    for item in &layout.items {
+        known.extend(collect_server_names(item));
+    }
+
+    for s in existing_servers {
+        if !known.iter().any(|n| n == &s.name) {
+            layout.items.push(LayoutItem::Server {
+                name: s.name.clone(),
+            });
+        }
+    }
+
+    let existing_names: Vec<String> = existing_servers.iter().map(|s| s.name.clone()).collect();
+    layout.items = layout
+        .items
+        .iter()
+        .filter_map(|item| clean_layout_item(item, &existing_names))
+        .collect();
+}
+
+fn clean_layout_item(item: &LayoutItem, existing_names: &[String]) -> Option<LayoutItem> {
+    match item {
+        LayoutItem::Server { name } => {
+            if existing_names.contains(name) {
+                Some(item.clone())
+            } else {
+                None
+            }
+        }
+        LayoutItem::Folder { id, name, items } => {
+            let cleaned_items: Vec<LayoutItem> = items
+                .iter()
+                .filter_map(|sub_item| clean_layout_item(sub_item, existing_names))
+                .collect();
+
+            if cleaned_items.is_empty() {
+                None
+            } else {
+                Some(LayoutItem::Folder {
+                    id: id.clone(),
+                    name: name.clone(),
+                    items: cleaned_items,
+                })
+            }
+        }
+    }
+}
+
+pub fn server_exists_anywhere(layout: &Layout, server_name: &str) -> bool {
+    for item in &layout.items {
+        match item {
+            LayoutItem::Server { name } => {
+                if name == server_name {
+                    return true;
+                }
+            }
+            LayoutItem::Folder { items, .. } => {
+                if server_exists_in_folder_items(items, server_name) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn server_exists_in_folder_items(items: &[LayoutItem], server_name: &str) -> bool {
+    for item in items {
+        match item {
+            LayoutItem::Server { name } => {
+                if name == server_name {
+                    return true;
+                }
+            }
+            LayoutItem::Folder {
+                items: sub_items, ..
+            } => {
+                if server_exists_in_folder_items(sub_items, server_name) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn remove_server_from_anywhere_except_folder(
+    layout: &mut Layout,
+    server_name: &str,
+    except_folder_id_or_name: &str,
+) -> bool {
+    let mut removed = false;
+
+    fn clean_items(
+        items: &[LayoutItem],
+        server_name: &str,
+        except_key: &str,
+        removed: &mut bool,
+    ) -> Vec<LayoutItem> {
+        items
+            .iter()
+            .filter_map(|item| match item {
+                LayoutItem::Server { name } => {
+                    if name == server_name {
+                        *removed = true;
+                        None
+                    } else {
+                        Some(item.clone())
+                    }
+                }
+                LayoutItem::Folder {
+                    id, name, items, ..
+                } => {
+                    if id == except_key || name == except_key {
+                        Some(item.clone())
+                    } else {
+                        let cleaned_items = clean_items(items, server_name, except_key, removed);
+                        Some(LayoutItem::Folder {
+                            id: id.clone(),
+                            name: name.clone(),
+                            items: cleaned_items,
+                        })
+                    }
+                }
+            })
+            .collect()
+    }
+
+    layout.items = clean_items(
+        &layout.items,
+        server_name,
+        except_folder_id_or_name,
+        &mut removed,
+    );
+
+    fn purge_empty(items: &mut Vec<LayoutItem>) {
+        let mut i = 0;
+        while i < items.len() {
+            match &mut items[i] {
+                LayoutItem::Folder { items: sub, .. } => {
+                    purge_empty(sub);
+                    if sub.is_empty() {
+                        items.remove(i);
+                        continue;
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+    purge_empty(&mut layout.items);
+
+    removed
+}
+
+pub fn remove_server_from_anywhere(layout: &mut Layout, server_name: &str) -> bool {
+    let mut removed = false;
+
+    layout.items = layout
+        .items
+        .iter()
+        .filter_map(|item| {
+            let cleaned = clean_item_remove_server(item, server_name);
+            if let Some((item, was_removed)) = cleaned {
+                if was_removed {
+                    removed = true;
+                }
+                Some(item)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    fn purge_empty(items: &mut Vec<LayoutItem>) {
+        let mut i = 0;
+        while i < items.len() {
+            match &mut items[i] {
+                LayoutItem::Folder { items: sub, .. } => {
+                    purge_empty(sub);
+                    if sub.is_empty() {
+                        items.remove(i);
+                        continue;
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+    purge_empty(&mut layout.items);
+
+    removed
+}
+
+fn clean_item_remove_server(item: &LayoutItem, server_name: &str) -> Option<(LayoutItem, bool)> {
+    match item {
+        LayoutItem::Server { name } => {
+            if name == server_name {
+                None
+            } else {
+                Some((item.clone(), false))
+            }
+        }
+        LayoutItem::Folder { name, items, .. } => {
+            let mut cleaned_items = Vec::new();
+            let mut removed_any = false;
+
+            for sub_item in items {
+                if let Some((cleaned_item, was_removed)) =
+                    clean_item_remove_server(sub_item, server_name)
+                {
+                    cleaned_items.push(cleaned_item);
+                    if was_removed {
+                        removed_any = true;
+                    }
+                } else {
+                    removed_any = true;
+                }
+            }
+
+            if cleaned_items.is_empty() {
+                None
+            } else {
+                Some((
+                    LayoutItem::Folder {
+                        id: match item {
+                            LayoutItem::Folder { id, .. } => id.clone(),
+                            _ => String::new(),
+                        },
+                        name: name.clone(),
+                        items: cleaned_items,
+                    },
+                    removed_any,
+                ))
+            }
+        }
+    }
+}
+
+fn find_item_index(layout: &Layout, predicate: impl Fn(&LayoutItem) -> bool) -> Option<usize> {
+    layout.items.iter().position(predicate)
+}
+
+fn find_folder_mut<'a>(
+    layout: &'a mut Layout,
+    folder_id_or_name: &'a str,
+) -> Option<&'a mut Vec<LayoutItem>> {
+    fn find_in<'a>(items: &'a mut [LayoutItem], key: &'a str) -> Option<&'a mut Vec<LayoutItem>> {
+        for item in items {
+            match item {
+                LayoutItem::Folder { id, name, items } => {
+                    if id == key || name == key {
+                        return Some(items);
+                    }
+                    if let Some(found) = find_in(items, key) {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+    find_in(&mut layout.items, folder_id_or_name)
+}
+
+pub fn move_into_folder(
+    layout: &mut Layout,
+    source: &str,
+    folder_id_or_name: &str,
+) -> Result<(), String> {
+    if source == folder_id_or_name {
+        return Ok(());
+    }
+    remove_server_from_anywhere(layout, source);
+    if let Some(items) = find_folder_mut(layout, folder_id_or_name) {
+        if !items
+            .iter()
+            .any(|item| matches!(item, LayoutItem::Server { name } if name == source))
+        {
+            items.push(LayoutItem::Server {
+                name: source.to_string(),
+            });
+        }
+        Ok(())
+    } else {
+        Err(format!("Folder '{}' not found", folder_id_or_name))
+    }
+}
+
+fn unique_folder_name(layout: &Layout, base: &str) -> String {
+    if !layout
+        .items
+        .iter()
+        .any(|i| matches!(i, LayoutItem::Folder { name, .. } if name == base))
+    {
+        return base.to_string();
+    }
+    let mut idx = 1u32;
+    loop {
+        let candidate = format!("{} ({})", base, idx);
+        if !layout
+            .items
+            .iter()
+            .any(|i| matches!(i, LayoutItem::Folder { name, .. } if name == &candidate))
+        {
+            return candidate;
+        }
+        idx += 1;
+    }
+}
+
+pub fn drop_onto_server_into(
+    layout: &mut Layout,
+    source: &str,
+    target_server: &str,
+) -> Result<(), String> {
+    if source == target_server {
+        return Ok(());
+    }
+
+    let mut target_folder_name: Option<String> = None;
+    for item in &layout.items {
+        if let LayoutItem::Folder { id: _, name, items } = item {
+            if collect_server_names(&LayoutItem::Folder {
+                id: String::new(),
+                name: name.clone(),
+                items: items.clone(),
+            })
+            .iter()
+            .any(|n| n == target_server)
+            {
+                target_folder_name = Some(name.clone());
+                break;
+            }
+        }
+    }
+
+    if let Some(folder_name) = target_folder_name {
+        move_into_folder(layout, source, &folder_name)
+    } else {
+        let target_index = find_item_index(
+            layout,
+            |item| matches!(item, LayoutItem::Server { name } if name == target_server),
+        )
+        .ok_or_else(|| format!("Target server '{}' not found", target_server))?;
+
+        remove_server_from_anywhere(layout, source);
+        layout.items.remove(target_index);
+
+        let folder_name = unique_folder_name(layout, &format!("Group: {}", target_server));
+        let mut items = vec![LayoutItem::Server {
+            name: target_server.to_string(),
+        }];
+        if !items
+            .iter()
+            .any(|item| matches!(item, LayoutItem::Server { name } if name == source))
+        {
+            items.push(LayoutItem::Server {
+                name: source.to_string(),
+            });
+        }
+        layout.items.insert(
+            target_index,
+            LayoutItem::Folder {
+                id: Uuid::new_v4().to_string(),
+                name: folder_name,
+                items,
+            },
+        );
+        Ok(())
+    }
+}
+
+pub fn drop_onto_folder_into(
+    layout: &mut Layout,
+    source: &str,
+    target_folder: &str,
+) -> Result<(), String> {
+    move_into_folder(layout, source, target_folder)
+}
+
+pub fn drop_onto_server_into_folder(
+    layout: &mut Layout,
+    source: &str,
+    target_server: &str,
+    parent_folder: &str,
+) -> Result<(), String> {
+    if source == target_server {
+        return Ok(());
+    }
+
+    let new_folder_id = Uuid::new_v4().to_string();
+    let folder_name = unique_folder_name(layout, &format!("Group: {}", target_server));
+
+    let parent_items: &mut Vec<LayoutItem> = find_folder_mut(layout, parent_folder)
+        .ok_or_else(|| format!("Parent folder '{}' not found", parent_folder))?;
+
+    let target_index = find_item_index_in_vec(parent_items, |item| match item {
+        LayoutItem::Server { name } => name == target_server,
+        _ => false,
+    })
+    .ok_or_else(|| {
+        format!(
+            "Target server '{}' not found in folder '{}'",
+            target_server, parent_folder
+        )
+    })?;
+
+    parent_items.remove(target_index);
+
+    let mut subfolder_items = vec![LayoutItem::Server {
+        name: target_server.to_string(),
+    }];
+    if !subfolder_items
+        .iter()
+        .any(|item| matches!(item, LayoutItem::Server { name } if name == source))
+    {
+        subfolder_items.push(LayoutItem::Server {
+            name: source.to_string(),
+        });
+    }
+
+    parent_items.insert(
+        target_index,
+        LayoutItem::Folder {
+            id: new_folder_id.clone(),
+            name: folder_name,
+            items: subfolder_items,
+        },
+    );
+
+    remove_server_from_anywhere_except_folder(layout, source, &new_folder_id);
+
+    Ok(())
+}
+
+pub fn drop_folder_onto_folder(
+    layout: &mut Layout,
+    source_folder: &str,
+    target_folder: &str,
+) -> Result<(), String> {
+    if source_folder == target_folder {
+        return Ok(());
+    }
+
+    let source_item = find_and_remove_folder(layout, source_folder)
+        .ok_or_else(|| format!("Source folder '{}' not found", source_folder))?;
+
+    let target_index = find_item_index(layout, |item| matches!(item, LayoutItem::Folder { id, name, .. } if id == target_folder || name == target_folder))
+        .ok_or_else(|| format!("Target folder '{}' not found", target_folder))?;
+
+    if let LayoutItem::Folder { name: _, items, .. } = &mut layout.items[target_index] {
+        items.push(source_item);
+        Ok(())
+    } else {
+        Err(format!("Target '{}' is not a folder", target_folder))
+    }
+}
+
+fn find_and_remove_folder(layout: &mut Layout, folder_id_or_name: &str) -> Option<LayoutItem> {
+    let index = find_item_index(
+        layout,
+        |item| matches!(item, LayoutItem::Folder { id, name, .. } if id == folder_id_or_name || name == folder_id_or_name),
+    )?;
+    Some(layout.items.remove(index))
+}
+
+fn find_item_index_in_vec<F>(items: &[LayoutItem], predicate: F) -> Option<usize>
+where
+    F: Fn(&LayoutItem) -> bool,
+{
+    items.iter().position(predicate)
+}
+
+pub fn get_folder_path(layout: &Layout, target_folder: &str) -> Vec<String> {
+    fn find_folder_path_recursive(
+        items: &[LayoutItem],
+        target: &str,
+        current_path: &mut Vec<String>,
+    ) -> bool {
+        for item in items {
+            match item {
+                LayoutItem::Folder {
+                    name,
+                    items: sub_items,
+                    ..
+                } => {
+                    current_path.push(name.clone());
+                    if name == target {
+                        return true;
+                    }
+                    if find_folder_path_recursive(sub_items, target, current_path) {
+                        return true;
+                    }
+                    current_path.pop();
+                }
+                LayoutItem::Server { .. } => {}
+            }
+        }
+        false
+    }
+
+    let mut path = Vec::new();
+    find_folder_path_recursive(&layout.items, target_folder, &mut path);
+    path
+}
+
+pub fn get_servers_in_folder(layout: &Layout, folder_name: &str) -> Vec<String> {
+    fn collect_servers_recursive(items: &[LayoutItem], target: &str, servers: &mut Vec<String>) {
+        for item in items {
+            match item {
+                LayoutItem::Folder {
+                    name,
+                    items: sub_items,
+                    ..
+                } => {
+                    if name == target {
+                        collect_all_servers_from_items(sub_items, servers);
+                        return;
+                    }
+                    collect_servers_recursive(sub_items, target, servers);
+                }
+                LayoutItem::Server { .. } => {}
+            }
+        }
+    }
+
+    fn collect_all_servers_from_items(items: &[LayoutItem], servers: &mut Vec<String>) {
+        for item in items {
+            match item {
+                LayoutItem::Server { name } => {
+                    servers.push(name.clone());
+                }
+                LayoutItem::Folder {
+                    items: sub_items, ..
+                } => {
+                    collect_all_servers_from_items(sub_items, servers);
+                }
+            }
+        }
+    }
+
+    let mut servers = Vec::new();
+    collect_servers_recursive(&layout.items, folder_name, &mut servers);
+    servers
+}
+
+pub fn get_items_in_folder(layout: &Layout, folder_name: &str) -> Vec<LayoutItem> {
+    fn find_folder_and_get_items(items: &[LayoutItem], target: &str) -> Option<Vec<LayoutItem>> {
+        for item in items {
+            match item {
+                LayoutItem::Folder {
+                    name,
+                    items: sub_items,
+                    ..
+                } => {
+                    if name == target {
+                        return Some(sub_items.clone());
+                    }
+                    if let Some(result) = find_folder_and_get_items(sub_items, target) {
+                        return Some(result);
+                    }
+                }
+                LayoutItem::Server { .. } => {}
+            }
+        }
+        None
+    }
+
+    find_folder_and_get_items(&layout.items, folder_name).unwrap_or_default()
+}
+
+pub fn rename_folder(
+    layout: &mut Layout,
+    key_id_or_name: &str,
+    new_name: &str,
+) -> Result<(), String> {
+    fn rename_in(items: &mut [LayoutItem], key: &str, new_name: &str) -> bool {
+        for item in items.iter_mut() {
+            match item {
+                LayoutItem::Folder { id, name, items } => {
+                    if id == key || name == key {
+                        *name = new_name.to_string();
+                        return true;
+                    }
+                    if rename_in(items, key, new_name) {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+
+    if rename_in(&mut layout.items, key_id_or_name, new_name) {
+        Ok(())
+    } else {
+        Err(format!("Folder '{}' not found", key_id_or_name))
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,12 @@
+pub mod layout;
 pub mod ssh_config;
 pub mod ssh_keys;
+
+pub use layout::{
+    drop_folder_onto_folder, drop_onto_folder_into, drop_onto_server_into,
+    drop_onto_server_into_folder, get_folder_path, get_items_in_folder, get_servers_in_folder,
+    load_layout, remove_server_from_anywhere, rename_folder, save_layout, server_exists_anywhere,
+};
 
 pub use ssh_config::{SshServer, delete_ssh_server, load_ssh_servers};
 pub use ssh_keys::{delete_key_pair, load_ssh_keys, read_key_content, regenerate_public_key};

--- a/src/ui/component/folder_card.rs
+++ b/src/ui/component/folder_card.rs
@@ -1,0 +1,114 @@
+use gtk4::gdk;
+use gtk4::glib::Type;
+use gtk4::prelude::*;
+use gtk4::{Box as GtkBox, Frame, Image, Label, Orientation};
+use std::rc::Rc;
+
+pub struct FolderCardConfig<'a> {
+    pub folder_id: &'a str,
+    pub folder_name: &'a str
+}
+
+pub fn create_folder_card(
+    cfg: FolderCardConfig,
+    _parent_window: Option<&libadwaita::ApplicationWindow>,
+    on_changed: Option<Rc<dyn Fn() + 'static>>,
+    on_folder_click: Option<Rc<dyn Fn(&str) + 'static>>,
+) -> Frame {
+    let card = Frame::new(None);
+    card.add_css_class("server-card");
+    card.add_css_class("hoverable");
+    card.set_can_focus(true);
+    card.set_focus_on_click(true);
+    card.set_cursor_from_name(Some("pointer"));
+    card.set_margin_start(8);
+    card.set_margin_end(8);
+    card.set_margin_top(8);
+    card.set_margin_bottom(8);
+    card.set_width_request(300);
+
+    let main_container = GtkBox::new(Orientation::Horizontal, 12);
+    main_container.set_margin_top(16);
+    main_container.set_margin_bottom(16);
+    main_container.set_margin_start(16);
+    main_container.set_margin_end(16);
+
+    let folder_icon = Image::from_icon_name("folder-symbolic");
+    folder_icon.set_icon_size(gtk4::IconSize::Large);
+    folder_icon.set_halign(gtk4::Align::Start);
+    folder_icon.set_valign(gtk4::Align::Center);
+
+    main_container.append(&folder_icon);
+
+    let server_count = {
+        let servers = match crate::service::load_ssh_servers() {
+            Ok(v) => v,
+            Err(_) => vec![],
+        };
+        let layout = crate::service::load_layout(&servers);
+        crate::service::get_servers_in_folder(&layout, cfg.folder_name).len()
+    };
+
+    let info_label = Label::new(Some(&format!(
+        "{}\n({} serveurs)",
+        cfg.folder_name, server_count
+    )));
+    info_label.add_css_class("title-4");
+    info_label.set_halign(gtk4::Align::Start);
+    info_label.set_valign(gtk4::Align::Center);
+    info_label.set_hexpand(true);
+    main_container.append(&info_label);
+
+    let drop_target = gtk4::DropTarget::new(
+        Type::STRING,
+        gdk::DragAction::COPY.union(gdk::DragAction::MOVE),
+    );
+    {
+        let folder_id = cfg.folder_id.to_string();
+        let on_changed = on_changed.clone();
+        drop_target.connect_drop(move |_w, value, _x, _y| {
+            if let Ok(name) = value.get::<String>() {
+                let servers = match crate::service::load_ssh_servers() {
+                    Ok(v) => v,
+                    Err(_) => vec![],
+                };
+                let mut layout = crate::service::load_layout(&servers);
+
+                let is_server = crate::service::server_exists_anywhere(&layout, &name);
+
+                let result = if is_server {
+                    crate::service::drop_onto_folder_into(&mut layout, &name, &folder_id)
+                } else {
+                    crate::service::drop_folder_onto_folder(&mut layout, &name, &folder_id)
+                };
+
+                match result {
+                    Ok(_) => {
+                        let _ = crate::service::save_layout(&layout);
+                        if let Some(cb) = &on_changed {
+                            cb();
+                        }
+                        return true;
+                    }
+                    Err(e) => {
+                        eprintln!("Drop into folder failed: {}", e);
+                    }
+                }
+            }
+            false
+        });
+    }
+    card.add_controller(drop_target);
+
+    if let Some(on_folder_click) = on_folder_click {
+        let folder_name = cfg.folder_name.to_string();
+        let gesture = gtk4::GestureClick::new();
+        gesture.connect_released(move |_gesture, _n_press, _x, _y| {
+            on_folder_click(&folder_name);
+        });
+        card.add_controller(gesture);
+    }
+
+    card.set_child(Some(&main_container));
+    card
+}

--- a/src/ui/component/mod.rs
+++ b/src/ui/component/mod.rs
@@ -1,5 +1,7 @@
+pub mod folder_card;
 pub mod icon_button;
 pub mod server_card;
 pub mod ssh_key_card;
 
+pub use folder_card::{FolderCardConfig, create_folder_card};
 pub use server_card::create_server_card;

--- a/src/ui/modal/mod.rs
+++ b/src/ui/modal/mod.rs
@@ -7,3 +7,4 @@ pub mod export_key;
 pub mod generate_key;
 pub mod info_key;
 pub mod preference;
+pub mod rename;

--- a/src/ui/modal/rename.rs
+++ b/src/ui/modal/rename.rs
@@ -1,0 +1,55 @@
+use gtk4::{
+    Box, Button, Dialog, Entry, Orientation,
+    prelude::{BoxExt, ButtonExt, EditableExt, GtkWindowExt, WidgetExt},
+};
+
+pub fn create_rename_dialog(
+    title: &str,
+    initial_text: &str,
+    on_save: Option<std::boxed::Box<dyn Fn(String) + 'static>>,
+    parent_window: Option<&gtk4::Window>,
+) -> Dialog {
+    let dialog = Dialog::builder()
+        .title(title)
+        .modal(true)
+        .resizable(false)
+        .decorated(true)
+        .build();
+
+    if let Some(parent) = parent_window {
+        dialog.set_transient_for(Some(parent));
+    }
+
+    let content_box = Box::new(Orientation::Vertical, 12);
+    content_box.set_margin_top(20);
+    content_box.set_margin_bottom(20);
+    content_box.set_margin_start(24);
+    content_box.set_margin_end(24);
+
+    let entry = Entry::builder().text(initial_text).build();
+    content_box.append(&entry);
+
+    dialog.set_child(Some(&content_box));
+
+    let save_button = Button::builder()
+        .label("Save")
+        .css_classes(vec!["suggested-action"])
+        .build();
+
+    content_box.append(&save_button);
+
+    save_button.connect_clicked({
+        let entry = entry.clone();
+        let dialog = dialog.clone();
+        let on_save_cb = on_save;
+        move |_| {
+            let text = entry.text().to_string();
+            if let Some(cb) = &on_save_cb {
+                cb(text);
+            }
+            dialog.close();
+        }
+    });
+
+    dialog
+}

--- a/src/ui/tab/server.rs
+++ b/src/ui/tab/server.rs
@@ -1,15 +1,32 @@
-use crate::service::{SshServer, load_ssh_servers};
-use crate::ui::component::create_server_card;
+use crate::service::{
+    SshServer, drop_onto_folder_into, get_folder_path, get_items_in_folder, get_servers_in_folder,
+    layout::LayoutItem, load_layout, load_ssh_servers, remove_server_from_anywhere, save_layout,
+};
 use crate::ui::component::icon_button::create_icon_button;
+use crate::ui::component::{FolderCardConfig, create_folder_card, create_server_card};
+use crate::ui::modal::rename::create_rename_dialog;
+use gtk4::gdk;
+use gtk4::glib::Type;
 use gtk4::prelude::*;
-use gtk4::{Box, Entry, Label, Orientation, ScrolledWindow};
+use gtk4::{Box, Button, DropTarget, Entry, Label, Orientation, ScrolledWindow};
 use libadwaita::StatusPage;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+fn count_servers_recursive(items: &[LayoutItem]) -> usize {
+    let mut count = 0;
+    for item in items {
+        match item {
+            LayoutItem::Server { .. } => count += 1,
+            LayoutItem::Folder { items, .. } => count += count_servers_recursive(items),
+        }
+    }
+    count
+}
+
 pub fn create_server_tab(
     parent_window: Option<&libadwaita::ApplicationWindow>,
-) -> (Box, Rc<dyn Fn()>) {
+) -> (Box, Rc<dyn Fn() + '_>) {
     let container = Box::new(Orientation::Vertical, 0);
 
     let header_container = Box::new(Orientation::Vertical, 20);
@@ -99,12 +116,206 @@ pub fn create_server_tab(
     let servers_data = Rc::new(RefCell::new(all_servers));
     let server_cards = Rc::new(RefCell::new(Vec::new()));
 
+    let current_folder = Rc::new(RefCell::new(None::<String>));
+
+    let breadcrumb_container = Box::new(Orientation::Horizontal, 8);
+    breadcrumb_container.set_margin_start(20);
+    breadcrumb_container.set_margin_top(10);
+    breadcrumb_container.set_margin_bottom(10);
+    breadcrumb_container.set_halign(gtk4::Align::Start);
+
+    let back_button = Button::builder()
+        .icon_name("go-previous-symbolic")
+        .css_classes(vec!["circular", "flat"])
+        .tooltip_text("Back to parent folder")
+        .build();
+    back_button.set_sensitive(false);
+
+    let hosts_button = Button::builder()
+        .label("Hosts")
+        .css_classes(vec!["flat"])
+        .build();
+    hosts_button.add_css_class("title-3");
+
+    let hosts_drop_target = DropTarget::new(Type::STRING, gdk::DragAction::MOVE);
+    {
+        let servers_data = Rc::clone(&servers_data);
+        let refresh_fn_storage = Rc::clone(&refresh_fn_storage);
+        hosts_drop_target.connect_drop(move |_w, value, _x, _y| {
+            if let Ok(server_name) = value.get::<String>() {
+                let mut layout = {
+                    let servers = servers_data.borrow();
+                    load_layout(&servers)
+                }; // servers borrow is released here
+
+                remove_server_from_anywhere(&mut layout, &server_name);
+
+                layout.items.push(LayoutItem::Server { name: server_name });
+
+                if let Err(e) = save_layout(&layout) {
+                    eprintln!("Failed to save layout: {}", e);
+                } else {
+                    if let Some(refresh_fn) = refresh_fn_storage.borrow().as_ref() {
+                        refresh_fn();
+                    }
+                    return true;
+                }
+            }
+            false
+        });
+    }
+    hosts_button.add_controller(hosts_drop_target);
+
+    container.append(&breadcrumb_container);
+
+    let update_breadcrumb = {
+        let breadcrumb_container = breadcrumb_container.clone();
+        let back_button = back_button.clone();
+        let hosts_button = hosts_button.clone();
+        let servers_data = Rc::clone(&servers_data);
+        let current_folder = Rc::clone(&current_folder);
+        let refresh_fn_storage = Rc::clone(&refresh_fn_storage);
+
+        Rc::new(move || {
+            while let Some(child) = breadcrumb_container.first_child() {
+                breadcrumb_container.remove(&child);
+            }
+
+            breadcrumb_container.append(&back_button);
+            breadcrumb_container.append(&hosts_button);
+
+            if let Some(ref folder_name) = *current_folder.borrow() {
+                let servers = servers_data.borrow();
+                let layout = load_layout(&servers);
+                let path = get_folder_path(&layout, folder_name);
+
+                for (_i, folder_in_path) in path.iter().enumerate() {
+                    let separator = Label::new(Some(">"));
+                    separator.add_css_class("dim-label");
+                    breadcrumb_container.append(&separator);
+
+                    let folder_button = Button::builder()
+                        .label(folder_in_path)
+                        .css_classes(vec!["flat"])
+                        .build();
+                    folder_button.add_css_class("title-3");
+
+                    let current_folder_clone = Rc::clone(&current_folder);
+                    let folder_name_clone = folder_in_path.clone();
+                    let refresh_fn_storage_click = Rc::clone(&refresh_fn_storage);
+
+                    folder_button.connect_clicked(move |_| {
+                        *current_folder_clone.borrow_mut() = Some(folder_name_clone.clone());
+                        if let Some(refresh_fn) = refresh_fn_storage_click.borrow().as_ref() {
+                            refresh_fn();
+                        }
+                    });
+
+                    let folder_drop_target = DropTarget::new(Type::STRING, gdk::DragAction::MOVE);
+                    {
+                        let servers_data_clone = Rc::clone(&servers_data);
+                        let refresh_fn_storage_clone = Rc::clone(&refresh_fn_storage);
+                        let folder_name_for_drop = folder_in_path.clone();
+                        folder_drop_target.connect_drop(move |_w, value, _x, _y| {
+                            if let Ok(server_name) = value.get::<String>() {
+                                let mut layout = {
+                                    let servers = servers_data_clone.borrow();
+                                    load_layout(&servers)
+                                };
+
+                                if let Err(e) = drop_onto_folder_into(
+                                    &mut layout,
+                                    &server_name,
+                                    &folder_name_for_drop,
+                                ) {
+                                    eprintln!("Failed to move server to folder: {}", e);
+                                } else {
+                                    if let Err(e) = save_layout(&layout) {
+                                        eprintln!("Failed to save layout: {}", e);
+                                    } else {
+                                        if let Some(refresh_fn) =
+                                            refresh_fn_storage_clone.borrow().as_ref()
+                                        {
+                                            refresh_fn();
+                                        }
+                                        return true;
+                                    }
+                                }
+                            }
+                            false
+                        });
+                    }
+                    folder_button.add_controller(folder_drop_target);
+
+                    breadcrumb_container.append(&folder_button);
+                }
+
+                if let Some(ref folder_name) = *current_folder.borrow() {
+                    let separator = Label::new(Some(">"));
+                    separator.add_css_class("dim-label");
+                    breadcrumb_container.append(&separator);
+
+                    let edit_button = Button::builder()
+                        .icon_name("document-edit-symbolic")
+                        .css_classes(vec!["circular", "flat"])
+                        .tooltip_text("Edit folder name")
+                        .build();
+
+                    let current_folder_clone = Rc::clone(&current_folder);
+                    let servers_data_clone = Rc::clone(&servers_data);
+                    let refresh_fn_storage_clone = Rc::clone(&refresh_fn_storage);
+                    let folder_name_initial = folder_name.clone();
+                    edit_button.connect_clicked(move |_| {
+                        let value_servers = servers_data_clone.clone();
+                        let value_current = current_folder_clone.clone();
+                        let value_key = folder_name_initial.clone();
+                        let value_refresh = refresh_fn_storage_clone.clone();
+                        let dialog = create_rename_dialog(
+                            "Rename Folder",
+                            &folder_name_initial,
+                            Some(std::boxed::Box::new(move |new_name: String| {
+                                {
+                                    let servers = value_servers.borrow();
+                                    let mut layout = load_layout(&servers);
+                                    if let Err(e) = crate::service::rename_folder(
+                                        &mut layout,
+                                        &value_key,
+                                        &new_name,
+                                    ) {
+                                        eprintln!("Failed to rename folder: {}", e);
+                                    } else if let Err(e) = save_layout(&layout) {
+                                        eprintln!("Failed to save layout: {}", e);
+                                    } else {
+                                        *value_current.borrow_mut() = Some(new_name.clone());
+                                    }
+                                }
+                                if let Some(cb) = value_refresh.borrow().as_ref() {
+                                    cb();
+                                }
+                            })),
+                            None,
+                        );
+                        dialog.show();
+                    });
+
+                    breadcrumb_container.append(&edit_button);
+                }
+
+                back_button.set_sensitive(true);
+            } else {
+                back_button.set_sensitive(false);
+            }
+        })
+    };
+
     let create_server_cards = {
         let servers_data = Rc::clone(&servers_data);
         let server_cards = Rc::clone(&server_cards);
         let servers_grid = servers_grid.clone();
         let parent_window_clone = parent_window.cloned();
         let refresh_fn_storage = Rc::clone(&refresh_fn_storage);
+        let current_folder = Rc::clone(&current_folder);
+
         Rc::new(move |filter: &str, _refresh_fn: Option<&Rc<dyn Fn()>>| {
             while let Some(child) = servers_grid.first_child() {
                 servers_grid.remove(&child);
@@ -121,9 +332,31 @@ pub fn create_server_tab(
             *servers_data.borrow_mut() = updated_servers;
 
             let servers = servers_data.borrow();
-            let filtered_servers: Vec<&SshServer> = if filter.is_empty() {
-                servers.iter().collect()
-            } else {
+            let is_filtering = !filter.is_empty();
+            let current_folder_name = current_folder.borrow().clone();
+
+            let filtered_servers: Vec<&SshServer> = if let Some(folder_name) = &current_folder_name
+            {
+                let layout = load_layout(&servers);
+                let server_names = get_servers_in_folder(&layout, folder_name);
+                let mut folder_servers = Vec::new();
+
+                for server_name in server_names {
+                    if let Some(server) = servers.iter().find(|s| s.name == server_name) {
+                        folder_servers.push(server);
+                    }
+                }
+
+                if is_filtering {
+                    folder_servers.retain(|server| {
+                        server.name.to_lowercase().contains(&filter.to_lowercase())
+                            || server.hostname.as_ref().map_or(false, |hostname| {
+                                hostname.to_lowercase().contains(&filter.to_lowercase())
+                            })
+                    });
+                }
+                folder_servers
+            } else if is_filtering {
                 servers
                     .iter()
                     .filter(|server| {
@@ -133,13 +366,28 @@ pub fn create_server_tab(
                             })
                     })
                     .collect()
+            } else {
+                servers.iter().collect()
             };
 
-            if filtered_servers.is_empty() {
+            let should_show_empty = if let Some(ref folder_name) = current_folder_name {
+                let layout = load_layout(&servers);
+                let server_names = get_servers_in_folder(&layout, folder_name);
+                server_names.is_empty() && !is_filtering
+            } else {
+                filtered_servers.is_empty() && (is_filtering || current_folder_name.is_some())
+            };
+
+            if should_show_empty {
                 servers_grid.set_halign(gtk4::Align::Center);
                 servers_grid.set_valign(gtk4::Align::Center);
 
-                let status_page = if filter.is_empty() {
+                let status_page = if let Some(_) = current_folder_name {
+                    StatusPage::builder()
+                        .icon_name("folder-symbolic")
+                        .title("This folder is empty")
+                        .build()
+                } else if filter.is_empty() {
                     StatusPage::builder()
                         .icon_name("network-server-symbolic")
                         .title("No SSH servers found - Add servers to your config file")
@@ -160,38 +408,244 @@ pub fn create_server_tab(
                 current_row.set_halign(gtk4::Align::Start);
                 current_row.set_hexpand(true);
 
-                for (i, server) in filtered_servers.iter().enumerate() {
-                    let refresh_callback =
-                        refresh_fn_storage.borrow().as_ref().map(|f| Rc::clone(f));
-                    let server_card =
-                        create_server_card(server, parent_window_clone.as_ref(), refresh_callback);
-                    server_cards.borrow_mut().push(server_card.clone());
-                    current_row.append(&server_card);
+                let refresh_callback = refresh_fn_storage.borrow().as_ref().map(|f| Rc::clone(f));
 
-                    if (i + 1) % cards_per_row == 0 || i == filtered_servers.len() - 1 {
-                        servers_grid.append(&current_row);
-                        if i < filtered_servers.len() - 1 {
+                if let Some(ref folder_name) = current_folder_name {
+                    let layout = load_layout(&servers);
+                    let items_to_show = get_items_in_folder(&layout, folder_name);
+
+                    let mut folder_items: Vec<&LayoutItem> = Vec::new();
+                    let mut server_items: Vec<&LayoutItem> = Vec::new();
+                    for it in items_to_show.iter() {
+                        match it {
+                            LayoutItem::Folder { .. } => folder_items.push(it),
+                            _ => server_items.push(it),
+                        }
+                    }
+                    let ordered: Vec<&LayoutItem> = folder_items
+                        .into_iter()
+                        .chain(server_items.into_iter())
+                        .collect();
+
+                    for (i, item) in ordered.iter().enumerate() {
+                        match *item {
+                            LayoutItem::Server { name: server_name } => {
+                                if let Some(server) =
+                                    servers.iter().find(|s| s.name == *server_name)
+                                {
+                                    if !is_filtering
+                                        || server
+                                            .name
+                                            .to_lowercase()
+                                            .contains(&filter.to_lowercase())
+                                        || server.hostname.as_ref().map_or(false, |hostname| {
+                                            hostname.to_lowercase().contains(&filter.to_lowercase())
+                                        })
+                                    {
+                                        let server_card = create_server_card(
+                                            server,
+                                            parent_window_clone.as_ref(),
+                                            refresh_callback.clone(),
+                                            current_folder_name.clone(),
+                                        );
+                                        server_cards.borrow_mut().push(server_card.clone());
+                                        current_row.append(&server_card);
+                                    }
+                                }
+                            }
+                            LayoutItem::Folder { id, name, items } => {
+                                let subfolder_server_count = count_servers_recursive(items);
+                                if subfolder_server_count > 0 {
+                                    let current_folder_clone = Rc::clone(&current_folder);
+                                    let refresh_callback_clone = refresh_callback.clone();
+
+                                    let subfolder_name = name.clone();
+                                    let navigate_to_subfolder =
+                                        Rc::new(move |_subfolder_name: &str| {
+                                            *current_folder_clone.borrow_mut() =
+                                                Some(subfolder_name.clone());
+                                            if let Some(refresh_fn) = &refresh_callback_clone {
+                                                refresh_fn();
+                                            }
+                                        });
+
+                                    let subfolder_card = create_folder_card(
+                                        FolderCardConfig {
+                                            folder_id: id,
+                                            folder_name: name,
+                                        },
+                                        parent_window_clone.as_ref(),
+                                        refresh_callback.clone(),
+                                        Some(navigate_to_subfolder),
+                                    );
+                                    current_row.append(&subfolder_card);
+                                }
+                            }
+                        }
+
+                        if (i + 1) % cards_per_row == 0 || i == ordered.len() - 1 {
+                            servers_grid.append(&current_row);
+                            if i < ordered.len() - 1 {
+                                current_row = Box::new(Orientation::Horizontal, 12);
+                                current_row.set_halign(gtk4::Align::Start);
+                                current_row.set_hexpand(true);
+                            }
+                        }
+                    }
+                } else if is_filtering {
+                    for (i, server) in filtered_servers.iter().enumerate() {
+                        let server_card = create_server_card(
+                            server,
+                            parent_window_clone.as_ref(),
+                            refresh_callback.clone(),
+                            current_folder_name.clone(),
+                        );
+                        server_cards.borrow_mut().push(server_card.clone());
+                        current_row.append(&server_card);
+
+                        if (i + 1) % cards_per_row == 0 || i == filtered_servers.len() - 1 {
+                            servers_grid.append(&current_row);
+                            if i < filtered_servers.len() - 1 {
+                                current_row = Box::new(Orientation::Horizontal, 12);
+                                current_row.set_halign(gtk4::Align::Start);
+                                current_row.set_hexpand(true);
+                            }
+                        }
+                    }
+                } else {
+                    let layout = load_layout(&servers);
+                    let mut by_name: std::collections::HashMap<&str, &SshServer> =
+                        std::collections::HashMap::new();
+                    for s in servers.iter() {
+                        by_name.insert(&s.name, s);
+                    }
+
+                    let mut folder_items: Vec<&LayoutItem> = Vec::new();
+                    let mut server_items: Vec<&LayoutItem> = Vec::new();
+                    for it in layout.items.iter() {
+                        match it {
+                            LayoutItem::Folder { .. } => folder_items.push(it),
+                            _ => server_items.push(it),
+                        }
+                    }
+                    let ordered: Vec<&LayoutItem> = folder_items
+                        .into_iter()
+                        .chain(server_items.into_iter())
+                        .collect();
+
+                    let mut index_in_row = 0usize;
+                    for item in ordered.iter() {
+                        match *item {
+                            crate::service::layout::LayoutItem::Server { name } => {
+                                if let Some(server) = by_name.get::<str>(&name) {
+                                    let server_card = create_server_card(
+                                        server,
+                                        parent_window_clone.as_ref(),
+                                        refresh_callback.clone(),
+                                        current_folder_name.clone(),
+                                    );
+                                    server_cards.borrow_mut().push(server_card.clone());
+                                    current_row.append(&server_card);
+                                    index_in_row += 1;
+                                }
+                            }
+                            crate::service::layout::LayoutItem::Folder { id, name, items } => {
+                                let server_count = count_servers_recursive(items);
+                                if server_count > 0 {
+                                    let folder_name = name.to_string();
+                                    let current_folder_clone = Rc::clone(&current_folder);
+                                    let refresh_callback_clone = refresh_callback.clone();
+
+                                    let navigate_to_folder = Rc::new(move |_folder_name: &str| {
+                                        *current_folder_clone.borrow_mut() =
+                                            Some(folder_name.clone());
+                                        if let Some(refresh_fn) = &refresh_callback_clone {
+                                            refresh_fn();
+                                        }
+                                    });
+
+
+                                    let folder_card = create_folder_card(
+                                        FolderCardConfig {
+                                            folder_id: id,
+                                            folder_name: name,
+                                        },
+                                        parent_window_clone.as_ref(),
+                                        refresh_callback.clone(),
+                                        Some(navigate_to_folder),
+                                    );
+                                    current_row.append(&folder_card);
+                                    index_in_row += 1;
+                                }
+                            }
+                        }
+
+                        if index_in_row % cards_per_row == 0 {
+                            servers_grid.append(&current_row);
                             current_row = Box::new(Orientation::Horizontal, 12);
                             current_row.set_halign(gtk4::Align::Start);
                             current_row.set_hexpand(true);
                         }
+                    }
+
+                    if index_in_row % cards_per_row != 0 || index_in_row == 0 {
+                        servers_grid.append(&current_row);
                     }
                 }
             }
         })
     };
 
+    let navigate_to_hosts = {
+        let current_folder = Rc::clone(&current_folder);
+        let create_server_cards = Rc::clone(&create_server_cards);
+        let search_entry = search_entry.clone();
+        let update_breadcrumb = Rc::clone(&update_breadcrumb);
+        Rc::new(move || {
+            *current_folder.borrow_mut() = None;
+            let text = search_entry.text();
+            create_server_cards(&text, None);
+            update_breadcrumb();
+        })
+    };
+
+    let navigate_back = {
+        let current_folder = Rc::clone(&current_folder);
+        let create_server_cards = Rc::clone(&create_server_cards);
+        let search_entry = search_entry.clone();
+        let update_breadcrumb = Rc::clone(&update_breadcrumb);
+        Rc::new(move || {
+            *current_folder.borrow_mut() = None;
+            let text = search_entry.text();
+            create_server_cards(&text, None);
+            update_breadcrumb();
+        })
+    };
+
+    let navigate_to_hosts_clone = Rc::clone(&navigate_to_hosts);
+    hosts_button.connect_clicked(move |_| {
+        navigate_to_hosts_clone();
+    });
+
+    let navigate_back_clone = Rc::clone(&navigate_back);
+    back_button.connect_clicked(move |_| {
+        navigate_back_clone();
+    });
+
     let refresh_fn: Rc<dyn Fn()> = Rc::new({
         let search_entry = search_entry.clone();
         let create_server_cards = Rc::clone(&create_server_cards);
+        let update_breadcrumb = Rc::clone(&update_breadcrumb);
         move || {
             let text = search_entry.text();
             create_server_cards(&text, None);
+            update_breadcrumb();
         }
     });
 
     *refresh_fn_storage.borrow_mut() = Some(Rc::clone(&refresh_fn));
     create_server_cards("", Some(&refresh_fn));
+    update_breadcrumb();
 
     let create_server_cards_clone = Rc::clone(&create_server_cards);
     search_entry.connect_changed(move |entry| {


### PR DESCRIPTION
Introduces a new layout system for organizing servers and folders, including drag-and-drop support for moving servers and folders, renaming folders, and updating the UI to reflect these changes. Adds new dependencies (glib, uuid) and several new modules and components to support folder cards, layout logic, and modal dialogs for renaming. Updates existing UI components to support drag-and-drop and folder context.