### PR TITLE
Add SSH connection history feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +135,21 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "pure-rust-locales",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "core-foundation"
@@ -832,6 +856,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1319,12 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "quote"
@@ -1440,6 +1503,7 @@ name = "rustmius"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "chrono",
  "dirs",
  "glib 0.19.9",
  "gtk4",
@@ -2088,6 +2152,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,8 +2205,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2120,12 +2219,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 html-escape = "0.2"
+chrono = { version = "0.4", features = ["clock", "serde", "unstable-locales"] }
 uuid = { version = "1.8", features = ["v4", "fast-rng", "serde"] }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 #### Phase 1 - Enhanced Management (v0.3.0)
 - [x] 🔄 **Server Groups & Tags**: Organize servers by project or environment (https://github.com/Cleboost/Rustmius/pull/16)
-- [ ] 📊 **Connection History**: Track and manage recent connections
+- [x] 📊 **Connection History**: Track and manage recent connections (https://github.com/Cleboost/Rustmius/pull/19)
 - [x] 🔐 **Key Generation Wizard**: Guided SSH key creation with best practices (https://github.com/Cleboost/Rustmius/pull/9)
 - [ ] 📋 **Import/Export**: Backup and restore SSH configurations (https://github.com/Cleboost/Rustmius/pull/7)
 

--- a/src/service/history.rs
+++ b/src/service/history.rs
@@ -1,0 +1,104 @@
+use chrono::{DateTime, Local};
+use dirs::config_dir;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    #[serde(default)]
+    pub id: Option<String>,
+    pub server_name: String,
+    pub timestamp: String,
+}
+
+fn history_file_path() -> PathBuf {
+    let mut base = config_dir().unwrap_or_else(|| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        std::path::Path::new(&home).join(".config")
+    });
+    base.push("rustmius");
+    base.push("history.json");
+    base
+}
+
+pub fn load_history() -> Vec<HistoryEntry> {
+    let path = history_file_path();
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    let mut line_entries: Vec<HistoryEntry> = Vec::new();
+    let mut non_json_line_found = false;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<HistoryEntry>(line) {
+            Ok(entry) => line_entries.push(entry),
+            Err(_) => {
+                non_json_line_found = true;
+                break;
+            }
+        }
+    }
+    if !line_entries.is_empty() && !non_json_line_found {
+        return line_entries;
+    }
+
+    if let Ok(Value::Array(arr)) = serde_json::from_str::<Value>(&content) {
+        let mut entries: Vec<HistoryEntry> = Vec::new();
+        for v in arr {
+            if let Ok(entry) = serde_json::from_value::<HistoryEntry>(v) {
+                entries.push(entry);
+            }
+        }
+        return entries;
+    }
+
+    let mut entries: Vec<HistoryEntry> = Vec::new();
+    let mut stream = serde_json::Deserializer::from_str(&content).into_iter::<Value>();
+    while let Some(item) = stream.next() {
+        if let Ok(Value::Object(map)) = item {
+            if let Ok(entry) = serde_json::from_value::<Value>(Value::Object(map))
+                .and_then(|v| serde_json::from_value::<HistoryEntry>(v))
+            {
+                entries.push(entry);
+            }
+        }
+    }
+
+    entries
+}
+
+pub fn append_history(server_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let now: DateTime<Local> = Local::now();
+    let entry = HistoryEntry {
+        id: Some(Uuid::new_v4().to_string()),
+        server_name: server_name.to_string(),
+        timestamp: now.to_rfc3339(),
+    };
+
+    let path = history_file_path();
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+
+    let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+
+    let line = serde_json::to_string(&entry)?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,6 @@
+pub mod history;
 pub mod layout;
+pub mod settings;
 pub mod ssh_config;
 pub mod ssh_keys;
 
@@ -8,5 +10,7 @@ pub use layout::{
     load_layout, remove_server_from_anywhere, rename_folder, save_layout, server_exists_anywhere,
 };
 
+pub use history::{append_history, load_history};
+pub use settings::{load_settings, save_settings};
 pub use ssh_config::{SshServer, delete_ssh_server, load_ssh_servers};
 pub use ssh_keys::{delete_key_pair, load_ssh_keys, read_key_content, regenerate_public_key};

--- a/src/service/settings.rs
+++ b/src/service/settings.rs
@@ -1,0 +1,49 @@
+use dirs::config_dir;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    pub remember_servers: bool,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            remember_servers: false,
+        }
+    }
+}
+
+fn settings_file_path() -> PathBuf {
+    let mut base = config_dir().unwrap_or_else(|| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        std::path::Path::new(&home).join(".config")
+    });
+    base.push("rustmius");
+    base.push("settings.json");
+    base
+}
+
+pub fn load_settings() -> AppSettings {
+    let path = settings_file_path();
+    if let Ok(content) = fs::read_to_string(&path) {
+        if let Ok(parsed) = serde_json::from_str::<AppSettings>(&content) {
+            return parsed;
+        }
+    }
+    AppSettings::default()
+}
+
+pub fn save_settings(settings: &AppSettings) -> Result<(), Box<dyn std::error::Error>> {
+    let path = settings_file_path();
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    let json = serde_json::to_string_pretty(settings)?;
+    let mut file = fs::File::create(&path)?;
+    file.write_all(json.as_bytes())?;
+    Ok(())
+}

--- a/src/ui/bus.rs
+++ b/src/ui/bus.rs
@@ -1,0 +1,20 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+thread_local! {
+    static HISTORY_REFRESH: RefCell<Option<Rc<dyn Fn()>>> = RefCell::new(None);
+}
+
+pub fn set_history_refresh(cb: Option<Rc<dyn Fn()>>) {
+    HISTORY_REFRESH.with(|cell| {
+        *cell.borrow_mut() = cb;
+    });
+}
+
+pub fn emit_history_refresh() {
+    HISTORY_REFRESH.with(|cell| {
+        if let Some(cb) = cell.borrow().as_ref() {
+            cb();
+        }
+    });
+}

--- a/src/ui/component/server_card.rs
+++ b/src/ui/component/server_card.rs
@@ -1,4 +1,6 @@
 use crate::service::SshServer;
+use crate::service::{append_history, load_settings};
+use crate::ui::bus::emit_history_refresh;
 use crate::ui::modal::{
     delete_server::create_delete_server_dialog, edit_server::create_edit_server_dialog,
 };
@@ -8,8 +10,6 @@ use gtk4::prelude::*;
 use gtk4::{Box as GtkBox, Button, DragSource, Frame, Image, Label, Orientation};
 use libadwaita::prelude::AdwDialogExt;
 use std::process::Command;
-use crate::service::{append_history, load_settings};
-use crate::ui::bus::emit_history_refresh;
 use std::rc::Rc;
 
 pub fn create_server_card(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod bus;
 pub mod component;
 pub mod modal;
 pub mod tab;

--- a/src/ui/modal/preference.rs
+++ b/src/ui/modal/preference.rs
@@ -1,10 +1,10 @@
 use crate::service::ssh_config::{export_ssh_config_to_file, load_ssh_servers};
 use crate::service::{load_settings, save_settings};
-use std::rc::Rc;
 use libadwaita::{
     ActionRow, ComboRow, PreferencesDialog, PreferencesGroup, PreferencesPage, SpinRow, SwitchRow,
     prelude::*,
 };
+use std::rc::Rc;
 
 pub fn create_preference_dialog(on_settings_changed: Option<Rc<dyn Fn()>>) -> PreferencesDialog {
     let dialog = PreferencesDialog::builder()

--- a/src/ui/tab/history.rs
+++ b/src/ui/tab/history.rs
@@ -1,0 +1,96 @@
+use crate::service::load_history;
+use chrono::{DateTime, Local};
+use gtk4::prelude::*;
+use gtk4::{Box, Label, ListBox, ListBoxRow, Orientation, ScrolledWindow};
+use std::rc::Rc;
+
+fn build_list() -> ListBox {
+    let list = ListBox::new();
+    list.set_selection_mode(gtk4::SelectionMode::None);
+
+    let entries = load_history();
+    for (i, entry) in entries.iter().rev().enumerate() {
+        let row = ListBoxRow::new();
+
+        row.add_css_class(&format!("history-row-{}", i));
+
+        let row_box = Box::new(Orientation::Horizontal, 12);
+        row_box.set_margin_top(8);
+        row_box.set_margin_bottom(8);
+        row_box.set_margin_start(12);
+        row_box.set_margin_end(12);
+
+        let connection_icon = gtk4::Image::from_icon_name("network-wired-symbolic");
+        connection_icon.set_icon_size(gtk4::IconSize::Normal);
+        connection_icon.set_margin_end(8);
+        row_box.append(&connection_icon);
+
+        let text_container = Box::new(Orientation::Vertical, 4);
+        text_container.set_hexpand(true);
+
+        let name_label = Label::new(Some(&entry.server_name));
+        name_label.add_css_class("title-4");
+        name_label.set_halign(gtk4::Align::Start);
+
+        let when = match entry.timestamp.parse::<DateTime<Local>>() {
+            Ok(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            Err(_) => entry.timestamp.clone(),
+        };
+        let ts_label = Label::new(Some(&when));
+        ts_label.add_css_class("dim-label");
+        ts_label.set_halign(gtk4::Align::Start);
+
+        text_container.append(&name_label);
+        text_container.append(&ts_label);
+        row_box.append(&text_container);
+        row.set_child(Some(&row_box));
+        list.append(&row);
+    }
+    list
+}
+
+pub fn create_history_tab() -> (Box, Rc<dyn Fn()>) {
+    let container = Box::new(Orientation::Vertical, 0);
+
+    let header_container = Box::new(Orientation::Vertical, 20);
+    header_container.set_margin_top(20);
+    header_container.set_margin_bottom(20);
+    header_container.set_margin_start(12);
+    header_container.set_margin_end(12);
+    header_container.set_halign(gtk4::Align::Fill);
+    header_container.set_hexpand(true);
+
+    let title = Label::new(Some("History"));
+    title.add_css_class("title-1");
+    title.set_halign(gtk4::Align::Start);
+    header_container.append(&title);
+
+    let description = Label::new(Some("Historique des connexions SSH (à venir)"));
+    description.add_css_class("dim-label");
+    description.set_halign(gtk4::Align::Start);
+    header_container.append(&description);
+
+    container.append(&header_container);
+
+    let scrolled = ScrolledWindow::builder()
+        .hscrollbar_policy(gtk4::PolicyType::Automatic)
+        .vscrollbar_policy(gtk4::PolicyType::Automatic)
+        .hexpand(true)
+        .vexpand(true)
+        .build();
+    let list = build_list();
+    scrolled.set_child(Some(&list));
+    container.append(&scrolled);
+
+    let list_scrolled = scrolled.clone();
+    let refresh_fn: Rc<dyn Fn()> = Rc::new(move || {
+        if let Some(old_child) = list_scrolled.child() {
+            list_scrolled.set_child(None::<&gtk4::Widget>);
+            let _ = old_child;
+        }
+        let new_list = build_list();
+        list_scrolled.set_child(Some(&new_list));
+    });
+
+    (container, refresh_fn)
+}

--- a/src/ui/tab/mod.rs
+++ b/src/ui/tab/mod.rs
@@ -1,5 +1,7 @@
+pub mod history;
 pub mod key;
 pub mod server;
 
+pub use history::create_history_tab;
 pub use key::create_key_tab;
 pub use server::create_server_tab;


### PR DESCRIPTION
Introduces a history tracking system for SSH connections, including persistent storage and UI integration. Adds `history.rs` and `settings.rs` for managing history entries and user preferences, updates the main UI to conditionally show a History tab, and enables users to toggle history tracking in preferences. The server card now records connections to history if enabled, and the history tab displays recent connections.