### PR TITLE
fix: Add server folder management utilities

### DIFF
--- a/src/service/layout.rs
+++ b/src/service/layout.rs
@@ -757,6 +757,53 @@ pub fn get_items_in_folder(layout: &Layout, folder_name: &str) -> Vec<LayoutItem
     find_folder_and_get_items(&layout.items, folder_name).unwrap_or_default()
 }
 
+pub fn find_parent_folder_id_of_server(layout: &Layout, server_name: &str) -> Option<String> {
+    fn find_in(items: &[LayoutItem], target: &str) -> Option<String> {
+        for item in items {
+            match item {
+                LayoutItem::Folder { id, items: sub_items, .. } => {
+                    if sub_items
+                        .iter()
+                        .any(|i| matches!(i, LayoutItem::Server { name, .. } if name == target))
+                    {
+                        return Some(id.clone());
+                    }
+                    if let Some(found) = find_in(sub_items, target) {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    find_in(&layout.items, server_name)
+}
+
+pub fn insert_server_into_folder_with_display(
+    layout: &mut Layout,
+    server_name: &str,
+    folder_id_or_name: &str,
+    display_name: Option<String>,
+) -> Result<(), String> {
+    if let Some(items) = find_folder_mut(layout, folder_id_or_name) {
+        if !items
+            .iter()
+            .any(|i| matches!(i, LayoutItem::Server { name, .. } if name == server_name))
+        {
+            items.push(LayoutItem::Server {
+                name: server_name.to_string(),
+                display_name,
+            });
+        }
+        remove_server_from_anywhere_except_folder(layout, server_name, folder_id_or_name);
+        Ok(())
+    } else {
+        Err(format!("Folder '{}' not found", folder_id_or_name))
+    }
+}
+
 pub fn rename_folder(
     layout: &mut Layout,
     key_id_or_name: &str,

--- a/src/ui/modal/edit_server.rs
+++ b/src/ui/modal/edit_server.rs
@@ -245,6 +245,10 @@ fn save_server_config(
         Err(_) => vec![],
     };
 
+    let layout_before = crate::service::load_layout(&existing_servers);
+    let parent_folder_id_before =
+        crate::service::layout::find_parent_folder_id_of_server(&layout_before, old_name);
+
     let (new_ssh_host_name, final_display_name) =
         generate_valid_hostname(new_display_name, &existing_servers);
 
@@ -326,17 +330,24 @@ fn save_server_config(
         match crate::service::load_ssh_servers() {
             Ok(servers2) => {
                 let mut layout = crate::service::load_layout(&servers2);
+                let parent_folder_id = parent_folder_id_before;
 
                 crate::service::remove_server_from_anywhere(&mut layout, old_name);
-
                 crate::service::remove_server_from_anywhere(&mut layout, &new_ssh_host_name);
 
-                layout
-                    .items
-                    .push(crate::service::layout::LayoutItem::Server {
+                if let Some(folder_id) = parent_folder_id {
+                    let _ = crate::service::layout::insert_server_into_folder_with_display(
+                        &mut layout,
+                        &new_ssh_host_name,
+                        &folder_id,
+                        Some(final_display_name.clone()),
+                    );
+                } else {
+                    layout.items.push(crate::service::layout::LayoutItem::Server {
                         name: new_ssh_host_name.clone(),
                         display_name: Some(final_display_name.clone()),
                     });
+                }
 
                 println!(
                     "Serveur '{}' remplacé par '{}' avec le nom d'affichage '{}'",


### PR DESCRIPTION
Introduces functions to find a server's parent folder and insert a server into a folder with a display name in layout.rs. Updates edit_server modal logic to preserve server folder placement when renaming or editing servers.