### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,5 +1,8 @@
 name: Manual AUR Publish
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Cleboost/Rustmius/security/code-scanning/2](https://github.com/Cleboost/Rustmius/security/code-scanning/2)

To fix the problem, add a `permissions` block that restricts the GITHUB_TOKEN's capabilities. Since this workflow only deals with pushing to the AUR (via SSH), it does not need any write permissions to the GitHub repository. It's best to set `contents: read` (the lowest level necessary for most actions) at the workflow level, making it apply to all jobs unless overridden. The change should be made at the top of the `.github/workflows/aur.yml`, immediately after (or before) the `on:` block, by inserting:

```yaml
permissions:
  contents: read
```

No code imports, method changes, or additional dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
