### PR TITLE
fix: Require SSH key selection to save new server

### DIFF
--- a/src/components/modal/NewServerModal.vue
+++ b/src/components/modal/NewServerModal.vue
@@ -70,7 +70,8 @@ const canSave = computed(
     () =>
         name.value.trim().length > 0 &&
         username.value.trim().length > 0 &&
-        ip.value.trim().length > 0,
+        ip.value.trim().length > 0 &&
+        selectedKeyId.value !== null,
 );
 
 const canTestConnection = computed(


### PR DESCRIPTION
Updated the save button logic in NewServerModal to require an SSH key to be selected before allowing the server to be saved. This ensures users cannot create a server without specifying an SSH key.