### PR TITLE
ci(workflows): update concurrency group names for PR jobs in check.yml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check Knip
     runs-on: ubuntu-latest
     concurrency:
-      group: pr-${{ github.event.pull_request.number }}
+      group: pr-knip-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     name: Build Project
     runs-on: ubuntu-latest
     concurrency:
-      group: pr-${{ github.event.pull_request.number }}
+      group: pr-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
     steps:


### PR DESCRIPTION
This pull request updates the concurrency group names in the GitHub Actions workflow file `.github/workflows/check.yml` to improve clarity and organization of workflow runs.

Workflow configuration improvements:

* Changed the concurrency group name for the "Check Knip" job to `pr-knip-${{ github.event.pull_request.number }}` for clearer identification of Knip-related runs.
* Changed the concurrency group name for the "Build Project" job to `pr-build-${{ github.event.pull_request.number }}` to distinguish build runs from other workflow jobs.
* fix parallele build