### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,10 @@ jobs:
     name: Build (${{ matrix.suffix }})
     needs: prepare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      id-token: none
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/Cleboost/Rustmius/security/code-scanning/4](https://github.com/Cleboost/Rustmius/security/code-scanning/4)

Add an explicit `permissions` block to the `build` job in `.github/workflows/release.yml` so it no longer relies on inherited defaults.

Best fix here (without changing behavior): define job-level permissions for `build` as:
- `contents: read` (required for checkout)
- `actions: read` (safe minimal explicit access for actions metadata)
- `id-token: none` (explicitly deny if unused)

This keeps the job least-privileged and satisfies CodeQL’s requirement for explicit permission limits.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
