### PR TITLE
feat(monitor): add system monitoring feature with resource tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ name = "rustmius"
 version = "2.1.0"
 dependencies = [
  "anyhow",
+ "cairo-rs",
  "chrono",
  "directories",
  "gtk4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 directories = "5.0"
 oo7 = "0.6"
 chrono = "0.4"
+cairo-rs = { version = "0.21", features = ["use_glib"] }
 
 [profile.release]
 opt-level = 3

--- a/src/ssh_engine.rs
+++ b/src/ssh_engine.rs
@@ -81,7 +81,7 @@ pub fn deploy_pubkey(host: &SshHost, password: Option<String>, pubkey_content: &
     Ok(())
 }
 
-pub async fn run_remote_command(host: SshHost, password: Option<String>, command: &str) -> anyhow::Result<String> {
+pub fn run_remote_command(host: SshHost, password: Option<String>, command: &str) -> anyhow::Result<String> {
     let port = host.port.unwrap_or(22);
     let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()?;
     let mut tcp_opt = None;

--- a/src/ssh_engine.rs
+++ b/src/ssh_engine.rs
@@ -1,7 +1,7 @@
 use ssh2::Session;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
-use std::io::Write;
+use std::io::{Read, Write};
 use anyhow::Context;
 use crate::config_observer::{SshHost, expand_tilde};
 
@@ -79,4 +79,45 @@ pub fn deploy_pubkey(host: &SshHost, password: Option<String>, pubkey_content: &
     channel.close()?;
     channel.wait_close()?;
     Ok(())
+}
+
+pub async fn run_remote_command(host: SshHost, password: Option<String>, command: &str) -> anyhow::Result<String> {
+    let port = host.port.unwrap_or(22);
+    let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()?;
+    let mut tcp_opt = None;
+    for addr in addrs {
+        if let Ok(stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
+            tcp_opt = Some(stream);
+            break;
+        }
+    }
+    let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}", host.hostname))?;
+    let mut sess = Session::new()?;
+    sess.set_tcp_stream(tcp);
+    sess.handshake()?;
+
+    let user = host.user.as_deref().unwrap_or("root");
+    let mut authenticated = false;
+    if let Some(ref key_path) = host.identity_file {
+        let path = expand_tilde(key_path);
+        if sess.userauth_pubkey_file(user, None, &path, None).is_ok() {
+            authenticated = true;
+        }
+    }
+    if !authenticated && sess.userauth_agent(user).is_ok() {
+        authenticated = true;
+    }
+    if !authenticated && let Some(pass) = password && sess.userauth_password(user, &pass).is_ok() {
+        authenticated = true;
+    }
+    if !authenticated {
+        return Err(anyhow::anyhow!("Authentication failed"));
+    }
+
+    let mut channel = sess.channel_session()?;
+    channel.exec(command)?;
+    let mut output = String::new();
+    channel.read_to_string(&mut output)?;
+    channel.wait_close()?;
+    Ok(output)
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,3 +4,4 @@ pub mod server_list;
 pub mod add_server_dialog;
 pub mod file_explorer;
 pub mod ssh_keys;
+pub mod monitor;

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -208,9 +208,8 @@ impl SystemMonitor {
                            echo \"---IPS---\"; ip -brief addr show | awk '{print $1 \": \" $3}'; \
                            echo \"---RAM---\"; free -h | grep Mem | awk '{print $3 \" / \" $2}'; \
                            echo \"---RAM_P---\"; free | grep Mem | awk '{print $3/$2}'; \
-                           echo \"---DISK---\"; df -Ph / | tail -1 | awk '{print $3 \" / \" $2}'; \
-                           echo \"---DISK_P---\"; df -Ph / | tail -1 | awk '{print $5}' | tr -d '%'; \
-                           echo \"---CPU_P---\"; top -bn1 | grep \"Cpu(s)\" | sed \"s/.*, *\\([0-9.]*\\) id.*/\\1/\" | awk '{print 100 - $1}'";
+                           echo \"---DISK_ALL---\"; df -h / --output=pcent,used,size | awk 'NR==2 {print $1, $2, $3}'; \
+                           echo \"---CPU_P---\"; top -bn2 -d 0.2 | grep \"%Cpu\" | tail -1 | awk -F',' '{for(i=1;i<=NF;i++) if($i ~ /id/) print $i}' | awk '{print 100-$1}'";
 
                 let h = h_clone.clone();
                 let p = p_clone.clone();
@@ -245,16 +244,16 @@ impl SystemMonitor {
                                         st.ram_total = parts[1].to_string();
                                     }
                                 },
-                                "---RAM_P---" => st.target_ram = line.replace(',', ".").parse().unwrap_or(0.0),
-                                "---DISK---" => {
-                                    let parts: Vec<&str> = line.split(" / ").collect();
-                                    if parts.len() == 2 {
-                                        st.disk_used = parts[0].trim().to_string();
-                                        st.disk_total = parts[1].trim().to_string();
+                                "---RAM_P---" => st.target_ram = line.trim().replace(',', ".").parse().unwrap_or(0.0),
+                                "---DISK_ALL---" => {
+                                    let parts: Vec<&str> = line.split_whitespace().collect();
+                                    if parts.len() == 3 {
+                                        st.target_disk = parts[0].trim_end_matches('%').replace(',', ".").parse::<f64>().unwrap_or(0.0) / 100.0;
+                                        st.disk_used = parts[1].to_string();
+                                        st.disk_total = parts[2].to_string();
                                     }
                                 },
-                                "---DISK_P---" => st.target_disk = line.replace(',', ".").parse::<f64>().unwrap_or(0.0) / 100.0,
-                                "---CPU_P---" => st.target_cpu = line.replace(',', ".").parse::<f64>().unwrap_or(0.0) / 100.0,
+                                "---CPU_P---" => st.target_cpu = line.trim().replace(',', ".").parse::<f64>().unwrap_or(0.0) / 100.0,
                                 _ => {}
                             }
                         }

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -215,10 +215,8 @@ impl SystemMonitor {
                 let h = h_clone.clone();
                 let p = p_clone.clone();
                 
-                // Move SSH command to background thread to avoid freezing UI
                 let result = tokio::task::spawn_blocking(move || {
-                    let rt = tokio::runtime::Handle::current();
-                    rt.block_on(async { run_remote_command(h, p, cmd).await })
+                    run_remote_command(h, p, cmd)
                 }).await;
 
                 if let Ok(Ok(output)) = result {

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -1,0 +1,369 @@
+use gtk4::prelude::*;
+use crate::config_observer::SshHost;
+use crate::ssh_engine::run_remote_command;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+use gtk4::glib;
+
+pub struct SystemMonitor {
+    pub container: gtk4::ScrolledWindow,
+}
+
+struct MonitorState {
+    current_cpu: f64,
+    target_cpu: f64,
+    current_ram: f64,
+    target_ram: f64,
+    current_disk: f64,
+    target_disk: f64,
+    ram_used: String,
+    ram_total: String,
+    disk_used: String,
+    disk_total: String,
+    kernel: String,
+    os: String,
+    uptime: String,
+    cpu_model: String,
+    cpu_cores: String,
+    arch: String,
+    hostname: String,
+    ips: String,
+}
+
+impl SystemMonitor {
+    pub fn new(host: SshHost, password: Option<String>) -> Self {
+        let scrolled = gtk4::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk4::PolicyType::Never)
+            .build();
+        
+        let container = gtk4::Box::new(gtk4::Orientation::Vertical, 18);
+        container.set_margin_top(18);
+        container.set_margin_bottom(18);
+        container.set_margin_start(18);
+        container.set_margin_end(18);
+        scrolled.set_child(Some(&container));
+
+        let toolbar = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+        let refresh_label = gtk4::Label::new(Some("Refresh Rate:"));
+        let refresh_dropdown = gtk4::DropDown::from_strings(&["1s", "3s", "5s", "10s"]);
+        refresh_dropdown.set_selected(1);
+        toolbar.append(&refresh_label);
+        toolbar.append(&refresh_dropdown);
+        toolbar.set_halign(gtk4::Align::End);
+        container.append(&toolbar);
+
+        let sys_frame = gtk4::Frame::new(Some("System Information"));
+        let sys_grid = gtk4::Grid::builder()
+            .column_spacing(32)
+            .row_spacing(12)
+            .margin_top(12)
+            .margin_bottom(12)
+            .margin_start(12)
+            .margin_end(12)
+            .build();
+        
+        let hostname_label = Self::info_label("Hostname", "Loading...");
+        let os_label = Self::info_label("OS", "Loading...");
+        let kernel_label = Self::info_label("Kernel", "Loading...");
+        let uptime_label = Self::info_label("Uptime", "Loading...");
+        let cpu_model_label = Self::info_label("CPU Model", "Loading...");
+        let arch_label = Self::info_label("Architecture", "Loading...");
+
+        sys_grid.attach(&hostname_label.0, 0, 0, 1, 1);
+        sys_grid.attach(&hostname_label.1, 0, 1, 1, 1);
+        sys_grid.attach(&os_label.0, 1, 0, 1, 1);
+        sys_grid.attach(&os_label.1, 1, 1, 1, 1);
+        sys_grid.attach(&arch_label.0, 2, 0, 1, 1);
+        sys_grid.attach(&arch_label.1, 2, 1, 1, 1);
+        
+        sys_grid.attach(&kernel_label.0, 0, 2, 1, 1);
+        sys_grid.attach(&kernel_label.1, 0, 3, 1, 1);
+        sys_grid.attach(&uptime_label.0, 1, 2, 1, 1);
+        sys_grid.attach(&uptime_label.1, 1, 3, 1, 1);
+
+        sys_grid.attach(&cpu_model_label.0, 0, 4, 3, 1);
+        sys_grid.attach(&cpu_model_label.1, 0, 5, 3, 1);
+
+        sys_frame.set_child(Some(&sys_grid));
+        container.append(&sys_frame);
+
+        let resource_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 18);
+        resource_box.set_homogeneous(true);
+
+        let cpu_card = Self::resource_card("CPU Load", "");
+        let ram_card = Self::resource_card("RAM Capacity", "0/0 GB");
+        let disk_card = Self::resource_card("Disk Capacity", "0/0 GB");
+
+        resource_box.append(&cpu_card.0);
+        resource_box.append(&ram_card.0);
+        resource_box.append(&disk_card.0);
+        container.append(&resource_box);
+
+        let net_frame = gtk4::Frame::new(Some("Network Interfaces"));
+        let ips_label = gtk4::Label::builder()
+            .label("Loading...")
+            .halign(gtk4::Align::Start)
+            .margin_top(12)
+            .margin_bottom(12)
+            .margin_start(12)
+            .margin_end(12)
+            .wrap(true)
+            .build();
+        net_frame.set_child(Some(&ips_label));
+        container.append(&net_frame);
+
+        let state = Rc::new(RefCell::new(MonitorState {
+            current_cpu: 0.0,
+            target_cpu: 0.0,
+            current_ram: 0.0,
+            target_ram: 0.0,
+            current_disk: 0.0,
+            target_disk: 0.0,
+            ram_used: "0".to_string(),
+            ram_total: "0".to_string(),
+            disk_used: "0".to_string(),
+            disk_total: "0".to_string(),
+            kernel: "Loading...".to_string(),
+            os: "Loading...".to_string(),
+            uptime: "Loading...".to_string(),
+            cpu_model: "Loading...".to_string(),
+            cpu_cores: "0".to_string(),
+            arch: "Loading...".to_string(),
+            hostname: "Loading...".to_string(),
+            ips: "Loading...".to_string(),
+        }));
+
+        let s_cpu = state.clone();
+        cpu_card.1.set_draw_func(move |_, cr, w, h| {
+            if let Ok(st) = s_cpu.try_borrow() {
+                Self::draw_donut(cr, w as f64, h as f64, st.current_cpu);
+            }
+        });
+
+        let s_ram = state.clone();
+        ram_card.1.set_draw_func(move |_, cr, w, h| {
+            if let Ok(st) = s_ram.try_borrow() {
+                Self::draw_donut(cr, w as f64, h as f64, st.current_ram);
+            }
+        });
+
+        let s_disk = state.clone();
+        disk_card.1.set_draw_func(move |_, cr, w, h| {
+            if let Ok(st) = s_disk.try_borrow() {
+                Self::draw_donut(cr, w as f64, h as f64, st.current_disk);
+            }
+        });
+
+        let h_clone = host.clone();
+        let p_clone = password.clone();
+        let s_clone = state.clone();
+        let host_l = hostname_label.1.clone();
+        let os_l = os_label.1.clone();
+        let ker_l = kernel_label.1.clone();
+        let upt_l = uptime_label.1.clone();
+        let cpum_l = cpu_model_label.1.clone();
+        let arch_l = arch_label.1.clone();
+        let ram_detail_l = ram_card.2.clone();
+        let disk_detail_l = disk_card.2.clone();
+        let ips_l = ips_label.clone();
+        let c_draw = cpu_card.1.clone();
+        let r_draw = ram_card.1.clone();
+        let d_draw = disk_card.1.clone();
+        let container_weak = container.downgrade();
+        let refresh_drop = refresh_dropdown.clone();
+
+        let s_anim = state.clone();
+        let cw_anim = container.downgrade();
+        let cd_anim = c_draw.clone();
+        let rd_anim = r_draw.clone();
+        let dd_anim = d_draw.clone();
+        glib::timeout_add_local(Duration::from_millis(32), move || {
+            if cw_anim.upgrade().is_none() { return glib::ControlFlow::Break; }
+            if let Ok(mut st) = s_anim.try_borrow_mut() {
+                let step = 0.1;
+                st.current_cpu += (st.target_cpu - st.current_cpu) * step;
+                st.current_ram += (st.target_ram - st.current_ram) * step;
+                st.current_disk += (st.target_disk - st.current_disk) * step;
+                
+                cd_anim.queue_draw();
+                rd_anim.queue_draw();
+                dd_anim.queue_draw();
+            }
+            glib::ControlFlow::Continue
+        });
+
+        glib::MainContext::default().spawn_local(async move {
+            loop {
+                if container_weak.upgrade().is_none() { break; }
+                
+                let cmd = "export LC_ALL=C; \
+                           echo \"---OS---\"; cat /etc/os-release | grep PRETTY_NAME | cut -d'\"' -f2; \
+                           echo \"---KERNEL---\"; uname -r; \
+                           echo \"---UPTIME---\"; uptime -p | sed 's/up //'; \
+                           echo \"---CPU_MODEL---\"; cat /proc/cpuinfo | grep \"model name\" | head -1 | cut -d':' -f2 | xargs; \
+                           echo \"---CPU_CORES---\"; grep -c ^processor /proc/cpuinfo; \
+                           echo \"---ARCH---\"; uname -m; \
+                           echo \"---HOSTNAME---\"; hostname; \
+                           echo \"---IPS---\"; ip -brief addr show | awk '{print $1 \": \" $3}'; \
+                           echo \"---RAM---\"; free -h | grep Mem | awk '{print $3 \" / \" $2}'; \
+                           echo \"---RAM_P---\"; free | grep Mem | awk '{print $3/$2}'; \
+                           echo \"---DISK---\"; df -Ph / | tail -1 | awk '{print $3 \" / \" $2}'; \
+                           echo \"---DISK_P---\"; df -Ph / | tail -1 | awk '{print $5}' | tr -d '%'; \
+                           echo \"---CPU_P---\"; top -bn1 | grep \"Cpu(s)\" | sed \"s/.*, *\\([0-9.]*\\) id.*/\\1/\" | awk '{print 100 - $1}'";
+
+                let h = h_clone.clone();
+                let p = p_clone.clone();
+                
+                // Move SSH command to background thread to avoid freezing UI
+                let result = tokio::task::spawn_blocking(move || {
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(async { run_remote_command(h, p, cmd).await })
+                }).await;
+
+                if let Ok(Ok(output)) = result {
+                    if let Ok(mut st) = s_clone.try_borrow_mut() {
+                        let mut current_section = "";
+                        let mut ips = Vec::new();
+
+                        for line in output.lines() {
+                            if line.starts_with("---") && line.ends_with("---") {
+                                current_section = line;
+                                continue;
+                            }
+                            match current_section {
+                                "---OS---" => st.os = line.to_string(),
+                                "---KERNEL---" => st.kernel = line.to_string(),
+                                "---UPTIME---" => st.uptime = line.to_string(),
+                                "---CPU_MODEL---" => st.cpu_model = line.to_string(),
+                                "---CPU_CORES---" => st.cpu_cores = line.to_string(),
+                                "---ARCH---" => st.arch = line.to_string(),
+                                "---HOSTNAME---" => st.hostname = line.to_string(),
+                                "---IPS---" => if !line.is_empty() { ips.push(line); },
+                                "---RAM---" => {
+                                    let parts: Vec<&str> = line.split(" / ").collect();
+                                    if parts.len() == 2 {
+                                        st.ram_used = parts[0].to_string();
+                                        st.ram_total = parts[1].to_string();
+                                    }
+                                },
+                                "---RAM_P---" => st.target_ram = line.replace(',', ".").parse().unwrap_or(0.0),
+                                "---DISK---" => {
+                                    let parts: Vec<&str> = line.split(" / ").collect();
+                                    if parts.len() == 2 {
+                                        st.disk_used = parts[0].trim().to_string();
+                                        st.disk_total = parts[1].trim().to_string();
+                                    }
+                                },
+                                "---DISK_P---" => st.target_disk = line.replace(',', ".").parse::<f64>().unwrap_or(0.0) / 100.0,
+                                "---CPU_P---" => st.target_cpu = line.replace(',', ".").parse::<f64>().unwrap_or(0.0) / 100.0,
+                                _ => {}
+                            }
+                        }
+                        st.ips = ips.join("\n");
+                    }
+                }
+
+                if let Ok(st) = s_clone.try_borrow() {
+                    host_l.set_label(&st.hostname);
+                    os_l.set_label(&st.os);
+                    ker_l.set_label(&st.kernel);
+                    upt_l.set_label(&st.uptime);
+                    cpum_l.set_label(&format!("{} ({} Cores)", st.cpu_model, st.cpu_cores));
+                    arch_l.set_label(&st.arch);
+                    ram_detail_l.set_label(&format!("{} / {}", st.ram_used, st.ram_total));
+                    disk_detail_l.set_label(&format!("{} / {}", st.disk_used, st.disk_total));
+                    ips_l.set_label(&st.ips);
+                }
+
+                let secs = match refresh_drop.selected() {
+                    0 => 1,
+                    1 => 3,
+                    2 => 5,
+                    3 => 10,
+                    _ => 3,
+                };
+                glib::timeout_future(Duration::from_secs(secs)).await;
+            }
+        });
+
+        Self { container: scrolled }
+    }
+
+    fn info_label(title: &str, value: &str) -> (gtk4::Label, gtk4::Label) {
+        let t_lbl = gtk4::Label::builder()
+            .label(title)
+            .halign(gtk4::Align::Start)
+            .build();
+        t_lbl.add_css_class("caption");
+        t_lbl.set_opacity(0.7);
+
+        let v_lbl = gtk4::Label::builder()
+            .label(value)
+            .halign(gtk4::Align::Start)
+            .use_markup(true)
+            .build();
+        v_lbl.add_css_class("body");
+        (t_lbl, v_lbl)
+    }
+
+    fn resource_card(title: &str, detail: &str) -> (gtk4::Frame, gtk4::DrawingArea, gtk4::Label) {
+        let frame = gtk4::Frame::new(Some(title));
+        let bx = gtk4::Box::new(gtk4::Orientation::Vertical, 8);
+        bx.set_margin_top(12);
+        bx.set_margin_bottom(12);
+        bx.set_margin_start(12);
+        bx.set_margin_end(12);
+        
+        let da = gtk4::DrawingArea::builder()
+            .content_width(120)
+            .content_height(120)
+            .build();
+        
+        let detail_lbl = gtk4::Label::builder()
+            .label(detail)
+            .halign(gtk4::Align::Center)
+            .build();
+        detail_lbl.set_opacity(0.8);
+
+        bx.append(&da);
+        bx.append(&detail_lbl);
+        frame.set_child(Some(&bx));
+        (frame, da, detail_lbl)
+    }
+
+    fn draw_donut(cr: &gtk4::cairo::Context, width: f64, height: f64, percent: f64) {
+        let percent = percent.clamp(0.0, 1.0);
+        let center_x = width / 2.0;
+        let center_y = height / 2.0;
+        let radius = width.min(height) / 2.0 - 10.0;
+        let thickness = 14.0;
+
+        cr.set_source_rgba(0.5, 0.5, 0.5, 0.15);
+        cr.set_line_width(thickness);
+        let _ = cr.arc(center_x, center_y, radius, 0.0, 2.0 * std::f64::consts::PI);
+        let _ = cr.stroke();
+
+        let angle = percent * 2.0 * std::f64::consts::PI;
+        let (r, g, b) = if percent < 0.5 {
+            (percent * 2.0, 1.0, 0.2)
+        } else {
+            (1.0, 1.0 - (percent - 0.5) * 2.0, 0.2)
+        };
+        cr.set_source_rgb(r, g, b);
+        
+        cr.set_line_width(thickness);
+        cr.set_line_cap(gtk4::cairo::LineCap::Round);
+        let _ = cr.arc(center_x, center_y, radius, -std::f64::consts::FRAC_PI_2, angle - std::f64::consts::FRAC_PI_2);
+        let _ = cr.stroke();
+
+        cr.set_source_rgb(0.9, 0.9, 0.9);
+        cr.select_font_face("Sans", gtk4::cairo::FontSlant::Normal, gtk4::cairo::FontWeight::Bold);
+        cr.set_font_size(20.0);
+        let text = format!("{:.0}%", percent * 100.0);
+        if let Ok(extents) = cr.text_extents(&text) {
+            cr.move_to(center_x - extents.width() / 2.0, center_y + extents.height() / 2.0);
+            let _ = cr.show_text(&text);
+        }
+    }
+}

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -298,7 +298,7 @@ impl SystemMonitor {
         let v_lbl = gtk4::Label::builder()
             .label(value)
             .halign(gtk4::Align::Start)
-            .use_markup(true)
+            .use_markup(false)
             .build();
         v_lbl.add_css_class("body");
         (t_lbl, v_lbl)

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -3,6 +3,7 @@ use gtk4::{glib, gio};
 use crate::ui::server_list::{ServerList, ServerAction};
 use crate::ui::add_server_dialog::show_server_dialog;
 use crate::ui::file_explorer::FileExplorer;
+use crate::ui::monitor::SystemMonitor;
 use crate::ui::ssh_keys::build_ssh_keys_ui;
 use crate::config_observer::{add_host_to_config, delete_host_from_config, load_hosts};
 use vte4::prelude::*;
@@ -124,7 +125,7 @@ pub fn build_ui(app: &gtk4::Application) {
 
                     let monitor_btn = gtk4::Button::from_icon_name("utilities-system-monitor-symbolic");
                     monitor_btn.add_css_class("flat");
-                    monitor_btn.set_tooltip_text(Some("System Monitor (WIP)"));
+                    monitor_btn.set_tooltip_text(Some("System Monitor"));
 
                     let docker_btn = gtk4::Button::from_icon_name("view-grid-symbolic");
                     docker_btn.add_css_class("flat");
@@ -229,6 +230,69 @@ pub fn build_ui(app: &gtk4::Application) {
                             let ex_c = explorer.container.clone();
                             exp_close.connect_clicked(move |_| {
                                 let idx = nb_c.page_num(&ex_c);
+                                if let Some(i) = idx {
+                                    let current = nb_c.current_page();
+                                    if current == Some(i) && nb_c.n_pages() > 2 {
+                                        let target = if i > 0 { i - 1 } else { 1 };
+                                        nb_c.set_current_page(Some(target));
+                                    }
+                                    nb_c.remove_page(Some(i));
+                                }
+                            });
+                        });
+                    });
+
+                    let nb_mon = notebook.clone();
+                    let host_mon = host.clone();
+                    monitor_btn.connect_clicked(move |_| {
+                        let h_mon = host_mon.clone();
+                        let h_alias = h_mon.alias.clone();
+                        let nb_spawn = nb_mon.clone();
+
+                        glib::MainContext::default().spawn_local(async move {
+                            let mut password = None;
+                            if let Ok(keyring) = oo7::Keyring::new().await {
+                                let mut attr = std::collections::HashMap::new();
+                                let alias_lower = h_alias.to_lowercase();
+                                attr.insert("rustmius-server-alias", alias_lower.as_str());
+                                if let Ok(items) = keyring.search_items(&attr).await
+                                    && let Some(item) = items.first()
+                                        && let Ok(pass) = item.secret().await {
+                                            password = std::str::from_utf8(pass.as_ref()).map(String::from).ok();
+                                        }
+                            }
+
+                            let monitor = SystemMonitor::new(h_mon, password);
+
+                            let mut count = 0;
+                            for i in 0..nb_spawn.n_pages() {
+                                if let Some(p) = nb_spawn.nth_page(Some(i))
+                                    && p.widget_name().starts_with(&format!("monitor:{}", h_alias)) {
+                                        count += 1;
+                                    }
+                            }
+                            monitor.container.set_widget_name(&format!("monitor:{}:{}", h_alias, count));
+
+                            let display_name = if count > 0 { format!("📈 {} ({})", h_alias, count) } else { format!("📈 {}", h_alias) };
+                            let mon_tab_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+                            mon_tab_box.append(&gtk4::Label::new(Some(&display_name)));
+                            let mon_close = gtk4::Button::from_icon_name("window-close-symbolic");
+                            mon_close.add_css_class("flat");
+                            mon_tab_box.append(&mon_close);
+
+                            let mut ins_pos = nb_spawn.n_pages();
+                            for i in 0..nb_spawn.n_pages() {
+                                if let Some(c) = nb_spawn.nth_page(Some(i))
+                                    && c.widget_name() == "plus_tab_dummy" { ins_pos = i; break; }
+                            }
+                            nb_spawn.insert_page(&monitor.container, Some(&mon_tab_box), Some(ins_pos));
+                            nb_spawn.set_tab_reorderable(&monitor.container, true);
+                            nb_spawn.set_current_page(Some(ins_pos));
+
+                            let nb_c = nb_spawn.clone();
+                            let mo_c = monitor.container.clone();
+                            mon_close.connect_clicked(move |_| {
+                                let idx = nb_c.page_num(&mo_c);
                                 if let Some(i) = idx {
                                     let current = nb_c.current_page();
                                     if current == Some(i) && nb_c.n_pages() > 2 {


### PR DESCRIPTION
This pull request introduces a new SSH-based remote system monitor UI to the application, allowing users to view live system metrics (CPU, RAM, disk, network, etc.) for remote servers via SSH. The implementation includes both backend logic for running remote commands and a GTK4-based frontend for displaying the information in a user-friendly way. Additional minor changes include dependency updates and UI integration.

**New SSH Remote System Monitoring Feature:**

* Added a new `SystemMonitor` component in `src/ui/monitor.rs` that connects to a remote server using SSH, periodically fetches system information (CPU, RAM, disk, OS, uptime, network interfaces, etc.), and displays it with animated donut charts in a GTK4 UI. This includes smooth animation and refresh rate controls.

* Implemented `run_remote_command` in `src/ssh_engine.rs`, an async function for securely executing commands on a remote server via SSH, supporting multiple authentication methods (key, agent, password).

**UI Integration:**

* Integrated the new monitor UI into the main window: added a "System Monitor" button that opens a new tab for each server, handles password retrieval from the keyring, and manages tab creation/closing.

* Registered the new monitor module in the UI module tree (`src/ui/mod.rs`), and updated the monitor button tooltip to remove the "WIP" label. [[1]](diffhunk://#diff-1b16d2199af085af653f62d275312de8a650ede0fdb65a9d22c1b6d71951d458R7) [[2]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L127-R128)

**Dependency Updates:**

* Added the `cairo-rs` crate (with `use_glib` feature) to `Cargo.toml` for custom drawing in the donut charts.

**Other:**

* Minor import adjustments to support new functionality (e.g., importing `Read` in `src/ssh_engine.rs`, importing `SystemMonitor` in `src/ui/window.rs`). [[1]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL4-R4) [[2]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577R6)