### PR TITLE
feat: add Ctrl+Shift+C/V support to terminal

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1,5 +1,5 @@
 use gtk4::prelude::*;
-use gtk4::{glib, gio};
+use gtk4::{glib, gio, gdk};
 use crate::ui::server_list::{ServerList, ServerAction};
 use crate::ui::add_server_dialog::show_server_dialog;
 use crate::ui::file_explorer::FileExplorer;
@@ -138,6 +138,31 @@ pub fn build_ui(app: &gtk4::Application) {
 
                     let terminal = vte4::Terminal::new();
                     terminal.set_vexpand(true);
+
+                    let key_controller = gtk4::EventControllerKey::new();
+                    let terminal_clone = terminal.clone();
+                    key_controller.connect_key_pressed(move |_controller, keyval, _keycode, state| {
+                        let is_ctrl = state.contains(gdk::ModifierType::CONTROL_MASK);
+                        let is_shift = state.contains(gdk::ModifierType::SHIFT_MASK);
+
+                        if is_ctrl && is_shift {
+                            match keyval {
+                                gdk::Key::C => {
+                                    terminal_clone.copy_clipboard_format(vte4::Format::Text);
+                                    glib::Propagation::Stop
+                                }
+                                gdk::Key::V => {
+                                    terminal_clone.paste_clipboard();
+                                    glib::Propagation::Stop
+                                }
+                                _ => glib::Propagation::Proceed,
+                            }
+                        } else {
+                            glib::Propagation::Proceed
+                        }
+                    });
+                    terminal.add_controller(key_controller);
+
                     session_box.append(&terminal);
 
                     let mut count = 0;


### PR DESCRIPTION
This pull request adds keyboard shortcut support for copy and paste operations in the embedded terminal widget. Now, users can use Ctrl+Shift+C to copy and Ctrl+Shift+V to paste within the terminal.

**Terminal keyboard shortcut enhancements:**

* Added a `gtk4::EventControllerKey` to the terminal widget to handle key press events, enabling Ctrl+Shift+C for copying and Ctrl+Shift+V for pasting text within the terminal (`src/ui/window.rs`).
* Imported the `gdk` module to support keyboard event handling (`src/ui/window.rs`).