### PR TITLE
fix: preemptive tab closing to prevent flicker

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -167,7 +167,9 @@ pub fn build_ui(app: &gtk4::Application) {
                     let nb_close = notebook.clone();
                     let sb_close = session_box.clone();
 
-                    close_btn.connect_clicked(move |_| {
+                    let close_gesture = gtk4::GestureClick::new();
+                    close_gesture.connect_pressed(move |gesture, _, _, _| {
+                        gesture.set_state(gtk4::EventSequenceState::Claimed);
                         let idx = nb_close.page_num(&sb_close);
                         if let Some(i) = idx {
                             let current = nb_close.current_page();
@@ -178,6 +180,7 @@ pub fn build_ui(app: &gtk4::Application) {
                             nb_close.remove_page(Some(i));
                         }
                     });
+                    close_btn.add_controller(close_gesture);
 
                     let nb_exp = notebook.clone();
                     let host_exp = host.clone();
@@ -228,7 +231,10 @@ pub fn build_ui(app: &gtk4::Application) {
 
                             let nb_c = nb_spawn.clone();
                             let ex_c = explorer.container.clone();
-                            exp_close.connect_clicked(move |_| {
+
+                            let exp_close_gesture = gtk4::GestureClick::new();
+                            exp_close_gesture.connect_pressed(move |gesture, _, _, _| {
+                                gesture.set_state(gtk4::EventSequenceState::Claimed);
                                 let idx = nb_c.page_num(&ex_c);
                                 if let Some(i) = idx {
                                     let current = nb_c.current_page();
@@ -239,6 +245,7 @@ pub fn build_ui(app: &gtk4::Application) {
                                     nb_c.remove_page(Some(i));
                                 }
                             });
+                            exp_close.add_controller(exp_close_gesture);
                         });
                     });
 
@@ -291,7 +298,10 @@ pub fn build_ui(app: &gtk4::Application) {
 
                             let nb_c = nb_spawn.clone();
                             let mo_c = monitor.container.clone();
-                            mon_close.connect_clicked(move |_| {
+
+                            let mon_close_gesture = gtk4::GestureClick::new();
+                            mon_close_gesture.connect_pressed(move |gesture, _, _, _| {
+                                gesture.set_state(gtk4::EventSequenceState::Claimed);
                                 let idx = nb_c.page_num(&mo_c);
                                 if let Some(i) = idx {
                                     let current = nb_c.current_page();
@@ -302,6 +312,7 @@ pub fn build_ui(app: &gtk4::Application) {
                                     nb_c.remove_page(Some(i));
                                 }
                             });
+                            mon_close.add_controller(mon_close_gesture);
                         });
                     });
 


### PR DESCRIPTION
This pull request refactors how close actions are handled for certain UI components in the `build_ui` function within `src/ui/window.rs`. Instead of using the `connect_clicked` signal on close buttons, it now uses `GestureClick` controllers and their `connect_pressed` signals. This approach provides more flexibility and better integration with GTK4's event handling.

**UI event handling improvements:**

* Replaced `connect_clicked` signal handlers with `GestureClick` controllers and `connect_pressed` handlers for close actions on session, explorer, and monitor tabs, ensuring more robust and modern GTK4 event management. [[1]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L170-R172) [[2]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L231-R237) [[3]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L294-R304)
* Added each new `GestureClick` controller to the corresponding close button using `add_controller`. [[1]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577R183) [[2]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577R248) [[3]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577R315)
* Explicitly claims the gesture sequence with `gesture.set_state(gtk4::EventSequenceState::Claimed)` to prevent event propagation and ensure the close action is handled correctly. [[1]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L170-R172) [[2]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L231-R237) [[3]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L294-R304)