### PR TITLE
fix(ui): resolve double title bar

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -57,9 +57,10 @@ pub fn build_ui(app: &gtk4::Application) {
     let add_btn = gtk4::Button::from_icon_name("list-add-symbolic");
     add_btn.add_css_class("suggested-action");
     header.pack_start(&add_btn);
+    window.set_titlebar(Some(&header));
+
     let stack = gtk4::Stack::new();
     stack.set_transition_type(gtk4::StackTransitionType::Crossfade);
-    content_box.append(&header);
     content_box.append(&stack);
 
     let notebook = gtk4::Notebook::new();


### PR DESCRIPTION
This pull request makes a small UI improvement in the `build_ui` function of `src/ui/window.rs`. The main change is moving the header bar into the window's titlebar instead of the main content area, which is more in line with modern GTK application design.

UI improvements:

* Set the header bar as the window's titlebar using `window.set_titlebar(Some(&header))`, and removed it from the main content box.