### PR TITLE
refactor: unify SSH connection and authentication logic

### DIFF
--- a/src/sftp_engine.rs
+++ b/src/sftp_engine.rs
@@ -1,11 +1,9 @@
 use ssh2::Session;
-use std::net::{TcpStream, ToSocketAddrs};
-use std::time::Duration;
-use crate::config_observer::{SshHost, expand_tilde};
 use std::path::Path;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::collections::HashMap;
+use crate::config_observer::SshHost;
 
 #[derive(Debug, Clone)]
 pub struct RemoteFile {
@@ -35,45 +33,7 @@ fn get_or_connect_sftp(host: &SshHost, password: &Option<String>) -> anyhow::Res
             }
         }
 
-    let port = host.port.unwrap_or(22);
-    let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()?;
-    let mut tcp_opt = None;
-    for addr in addrs {
-        if let Ok(stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
-            tcp_opt = Some(stream);
-            break;
-        }
-    }
-    let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}", host.hostname))?;
-    let mut sess = Session::new()?;
-    sess.set_tcp_stream(tcp);
-    sess.handshake()?;
-
-    let user = host.user.as_deref().unwrap_or("root");
-    let mut authenticated = false;
-    if let Some(ref key_path) = host.identity_file {
-        let path = expand_tilde(key_path);
-        if sess.userauth_pubkey_file(user, None, &path, None).is_ok() {
-            println!("[DEBUG] SFTP connected to {} via Configure SSH Key ({})", host.hostname, key_path);
-            authenticated = true;
-        }
-    }
-    if !authenticated
-        && sess.userauth_agent(user).is_ok() {
-            println!("[DEBUG] SFTP connected to {} via SSH Agent", host.hostname);
-            authenticated = true;
-        }
-
-    if !authenticated
-        && let Some(pass) = password
-            && sess.userauth_password(user, pass).is_ok() {
-                println!("[DEBUG] SFTP connected to {} via Password", host.hostname);
-                authenticated = true;
-            }
-    if !authenticated {
-        return Err(anyhow::anyhow!("Authentication failed (tried key, password, and agent)"));
-    }
-
+    let sess = crate::ssh_engine::establish_ssh_session(host, password.as_deref())?;
     let sftp = sess.sftp()?;
     let active = Arc::new(ActiveSession { _sess: sess, sftp });
     if let Ok(mut pool) = get_session_pool().lock() {

--- a/src/ssh_engine.rs
+++ b/src/ssh_engine.rs
@@ -5,10 +5,11 @@ use std::io::{Read, Write};
 use anyhow::Context;
 use crate::config_observer::{SshHost, expand_tilde};
 
-#[allow(dead_code)]
-pub fn connect(host: &str, _user: &str) -> anyhow::Result<Session> {
-    let addrs = format!("{}:22", host).to_socket_addrs()
-        .with_context(|| format!("Failed to resolve {}:22", host))?;
+pub fn establish_ssh_session(host: &SshHost, password: Option<&str>) -> anyhow::Result<Session> {
+    let port = host.port.unwrap_or(22);
+    let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()
+        .with_context(|| format!("Failed to resolve {}:{}", host.hostname, port))?;
+    
     let mut tcp_opt = None;
     for addr in addrs {
         if let Ok(stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
@@ -16,54 +17,44 @@ pub fn connect(host: &str, _user: &str) -> anyhow::Result<Session> {
             break;
         }
     }
-    let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}:22", host))?;
+    
+    let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}", host.hostname))?;
     let mut sess = Session::new()
         .context("Failed to create SSH session")?;
     sess.set_tcp_stream(tcp);
     sess.handshake()
         .context("SSH handshake failed")?;
 
-    Ok(sess)
-}
-
-pub fn deploy_pubkey(host: &SshHost, password: Option<String>, pubkey_content: &str) -> anyhow::Result<()> {
-    let port = host.port.unwrap_or(22);
-    let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()?;
-    let mut tcp_opt = None;
-    for addr in addrs {
-        if let Ok(stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
-            tcp_opt = Some(stream);
-            break;
-        }
-    }
-    let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}", host.hostname))?;
-    let mut sess = Session::new()?;
-    sess.set_tcp_stream(tcp);
-    sess.handshake()?;
     let user = host.user.as_deref().unwrap_or("root");
     let mut authenticated = false;
+
     if let Some(ref key_path) = host.identity_file {
         let path = expand_tilde(key_path);
         if sess.userauth_pubkey_file(user, None, &path, None).is_ok() {
-            println!("[DEBUG] SSH deploy connected to {} via Configure SSH Key ({})", host.hostname, key_path);
             authenticated = true;
         }
     }
-    if !authenticated
-        && sess.userauth_agent(user).is_ok() {
-            println!("[DEBUG] SSH deploy connected to {} via SSH Agent", host.hostname);
-            authenticated = true;
-        }
 
-    if !authenticated
-        && let Some(pass) = password
-            && sess.userauth_password(user, &pass).is_ok() {
-                println!("[DEBUG] SSH deploy connected to {} via Password", host.hostname);
-                authenticated = true;
-            }
-    if !authenticated {
-        return Err(anyhow::anyhow!("Authentication failed (tried key, password, and agent)"));
+    if !authenticated && sess.userauth_agent(user).is_ok() {
+        authenticated = true;
     }
+
+    if !authenticated && let Some(pass) = password {
+        if sess.userauth_password(user, pass).is_ok() {
+            authenticated = true;
+        }
+    }
+
+    if authenticated {
+        Ok(sess)
+    } else {
+        Err(anyhow::anyhow!("Authentication failed for {}@{} (tried key, agent, and password)", user, host.hostname))
+    }
+}
+
+pub fn deploy_pubkey(host: &SshHost, password: Option<String>, pubkey_content: &str) -> anyhow::Result<()> {
+    let sess = establish_ssh_session(host, password.as_deref())?;
+    
     let mut channel = sess.channel_session()?;
     channel.exec("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")?;
 
@@ -82,37 +73,7 @@ pub fn deploy_pubkey(host: &SshHost, password: Option<String>, pubkey_content: &
 }
 
 pub fn run_remote_command(host: SshHost, password: Option<String>, command: &str) -> anyhow::Result<String> {
-    let port = host.port.unwrap_or(22);
-    let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()?;
-    let mut tcp_opt = None;
-    for addr in addrs {
-        if let Ok(stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
-            tcp_opt = Some(stream);
-            break;
-        }
-    }
-    let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}", host.hostname))?;
-    let mut sess = Session::new()?;
-    sess.set_tcp_stream(tcp);
-    sess.handshake()?;
-
-    let user = host.user.as_deref().unwrap_or("root");
-    let mut authenticated = false;
-    if let Some(ref key_path) = host.identity_file {
-        let path = expand_tilde(key_path);
-        if sess.userauth_pubkey_file(user, None, &path, None).is_ok() {
-            authenticated = true;
-        }
-    }
-    if !authenticated && sess.userauth_agent(user).is_ok() {
-        authenticated = true;
-    }
-    if !authenticated && let Some(pass) = password && sess.userauth_password(user, &pass).is_ok() {
-        authenticated = true;
-    }
-    if !authenticated {
-        return Err(anyhow::anyhow!("Authentication failed"));
-    }
+    let sess = establish_ssh_session(&host, password.as_deref())?;
 
     let mut channel = sess.channel_session()?;
     channel.exec(command)?;


### PR DESCRIPTION
This pull request refactors SSH connection and authentication logic to improve code reuse and maintainability. The main change is consolidating all SSH session establishment and authentication flows into a new function, `establish_ssh_session`, in `src/ssh_engine.rs`. This eliminates duplicated code and ensures consistent connection handling across the codebase.

**SSH Session Handling Refactor:**

* Introduced the `establish_ssh_session` function in `src/ssh_engine.rs`, which centralizes the logic for connecting to a remote host and handling authentication (via SSH key, agent, or password). This function is now used throughout the codebase for all SSH connections.
* Refactored `get_or_connect_sftp` in `src/sftp_engine.rs` to use the new `establish_ssh_session` function, removing duplicated connection and authentication code.
* Updated `deploy_pubkey` and `run_remote_command` in `src/ssh_engine.rs` to use `establish_ssh_session`, further reducing code duplication and improving error handling. [[1]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL8-R57) [[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL85-R76)

**Code Cleanup:**

* Removed unused imports and redundant code from `src/sftp_engine.rs` as part of the refactor.

This refactor makes the SSH connection process more robust and easier to maintain by ensuring all SSH interactions go through a single, well-defined path.