### PR TITLE
refactor: make SSH connection async using tokio::net::TcpStream

### DIFF
--- a/src/sftp_engine.rs
+++ b/src/sftp_engine.rs
@@ -40,13 +40,13 @@ async fn get_or_connect_sftp(host: &SshHost, password: &Option<String>) -> anyho
         }
     }
 
-    let host_cloned = host.clone();
-    let password_cloned = password.clone();
-    let sess = tokio::task::spawn_blocking(move || {
-        crate::ssh_engine::establish_ssh_session(&host_cloned, password_cloned.as_deref())
+    let sess = crate::ssh_engine::establish_ssh_session(host, password.clone()).await?;
+
+    let sftp_sess = sess.clone();
+    let sftp = tokio::task::spawn_blocking(move || {
+        sftp_sess.sftp()
     }).await??;
 
-    let sftp = sess.sftp()?;
     let active = Arc::new(ActiveSession { _sess: sess, sftp });
     *session_guard = Some(active.clone());
     

--- a/src/ssh_engine.rs
+++ b/src/ssh_engine.rs
@@ -1,84 +1,98 @@
 use ssh2::Session;
-use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
 use std::io::{Read, Write};
 use anyhow::Context;
 use crate::config_observer::{SshHost, expand_tilde};
+use tokio::net::{TcpStream, lookup_host};
 
-pub fn establish_ssh_session(host: &SshHost, password: Option<&str>) -> anyhow::Result<Session> {
+pub async fn establish_ssh_session(host: &SshHost, password: Option<String>) -> anyhow::Result<Session> {
     let port = host.port.unwrap_or(22);
-    let addrs = format!("{}:{}", host.hostname, port).to_socket_addrs()
-        .with_context(|| format!("Failed to resolve {}:{}", host.hostname, port))?;
+    let addr_str = format!("{}:{}", host.hostname, port);
+    
+    let addrs = lookup_host(&addr_str).await
+        .with_context(|| format!("Failed to resolve {}", addr_str))?;
     
     let mut tcp_opt = None;
     for addr in addrs {
-        if let Ok(stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
-            tcp_opt = Some(stream);
-            break;
+        if let Ok(stream) = tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(&addr)).await {
+            if let Ok(stream) = stream {
+                tcp_opt = Some(stream);
+                break;
+            }
         }
     }
     
     let tcp = tcp_opt.ok_or_else(|| anyhow::anyhow!("Connection timeout to {}", host.hostname))?;
-    let mut sess = Session::new()
-        .context("Failed to create SSH session")?;
-    sess.set_tcp_stream(tcp);
-    sess.handshake()
-        .context("SSH handshake failed")?;
+    let std_tcp = tcp.into_std()?;
+    std_tcp.set_nonblocking(false)?;
 
-    let user = host.user.as_deref().unwrap_or("root");
-    let mut authenticated = false;
+    let host_cloned = host.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut sess = Session::new()
+            .context("Failed to create SSH session")?;
+        sess.set_tcp_stream(std_tcp);
+        sess.handshake()
+            .context("SSH handshake failed")?;
 
-    if let Some(ref key_path) = host.identity_file {
-        let path = expand_tilde(key_path);
-        if sess.userauth_pubkey_file(user, None, &path, None).is_ok() {
+        let user = host_cloned.user.as_deref().unwrap_or("root");
+        let mut authenticated = false;
+
+        if let Some(ref key_path) = host_cloned.identity_file {
+            let path = expand_tilde(key_path);
+            if sess.userauth_pubkey_file(user, None, &path, None).is_ok() {
+                authenticated = true;
+            }
+        }
+
+        if !authenticated && sess.userauth_agent(user).is_ok() {
             authenticated = true;
         }
-    }
 
-    if !authenticated && sess.userauth_agent(user).is_ok() {
-        authenticated = true;
-    }
-
-    if !authenticated && let Some(pass) = password {
-        if sess.userauth_password(user, pass).is_ok() {
-            authenticated = true;
+        if !authenticated && let Some(pass) = password {
+            if sess.userauth_password(user, &pass).is_ok() {
+                authenticated = true;
+            }
         }
-    }
 
-    if authenticated {
-        Ok(sess)
-    } else {
-        Err(anyhow::anyhow!("Authentication failed for {}@{} (tried key, agent, and password)", user, host.hostname))
-    }
+        if authenticated {
+            Ok(sess)
+        } else {
+            Err(anyhow::anyhow!("Authentication failed for {}@{} (tried key, agent, and password)", user, host_cloned.hostname))
+        }
+    }).await?
 }
 
-pub fn deploy_pubkey(host: &SshHost, password: Option<String>, pubkey_content: &str) -> anyhow::Result<()> {
-    let sess = establish_ssh_session(host, password.as_deref())?;
+pub async fn deploy_pubkey(host: SshHost, password: Option<String>, pubkey_content: String) -> anyhow::Result<()> {
+    let sess = establish_ssh_session(&host, password).await?;
     
-    let mut channel = sess.channel_session()?;
-    channel.exec("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")?;
+    tokio::task::spawn_blocking(move || {
+        let mut channel = sess.channel_session()?;
+        channel.exec("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")?;
 
-    if pubkey_content.ends_with('\n') {
-        channel.write_all(pubkey_content.as_bytes())?;
-    } else {
-        let mut content = pubkey_content.to_owned();
-        content.push('\n');
-        channel.write_all(content.as_bytes())?;
-    }
-    channel.send_eof()?;
-    channel.wait_eof()?;
-    channel.close()?;
-    channel.wait_close()?;
-    Ok(())
+        if pubkey_content.ends_with('\n') {
+            channel.write_all(pubkey_content.as_bytes())?;
+        } else {
+            let mut content = pubkey_content.to_owned();
+            content.push('\n');
+            channel.write_all(content.as_bytes())?;
+        }
+        channel.send_eof()?;
+        channel.wait_eof()?;
+        channel.close()?;
+        channel.wait_close()?;
+        Ok(())
+    }).await?
 }
 
-pub fn run_remote_command(host: SshHost, password: Option<String>, command: &str) -> anyhow::Result<String> {
-    let sess = establish_ssh_session(&host, password.as_deref())?;
+pub async fn run_remote_command(host: SshHost, password: Option<String>, command: String) -> anyhow::Result<String> {
+    let sess = establish_ssh_session(&host, password).await?;
 
-    let mut channel = sess.channel_session()?;
-    channel.exec(command)?;
-    let mut output = String::new();
-    channel.read_to_string(&mut output)?;
-    channel.wait_close()?;
-    Ok(output)
+    tokio::task::spawn_blocking(move || {
+        let mut channel = sess.channel_session()?;
+        channel.exec(&command)?;
+        let mut output = String::new();
+        channel.read_to_string(&mut output)?;
+        channel.wait_close()?;
+        Ok(output)
+    }).await?
 }

--- a/src/ui/docker.rs
+++ b/src/ui/docker.rs
@@ -258,11 +258,9 @@ impl DockerManager {
                 let h_for_fetch = h.clone();
                 let p_for_fetch = p.clone();
                 let c_for_fetch = c.clone();
-                let result = tokio::task::spawn_blocking(move || {
-                    run_remote_command(h_for_fetch, p_for_fetch, &c_for_fetch)
-                }).await;
+                let result = run_remote_command(h_for_fetch, p_for_fetch, c_for_fetch).await;
 
-                if let Ok(Ok(output)) = result {
+                if let Ok(output) = result {
                     while let Some(child) = lb.first_child() { lb.remove(&child); }
                     for line in output.lines() {
                         let parts: Vec<&str> = line.split('\t').collect();
@@ -322,9 +320,7 @@ impl DockerManager {
                                 let c_str = cmd_str.clone();
                                 glib::MainContext::default().spawn_local(async move {
                                     let cmd = format!("DOCKER_BIN=$(if [ -w /var/run/docker.sock ]; then echo 'docker'; else echo 'sudo -n docker'; fi); $DOCKER_BIN {} {}", c_str, n_c);
-                                    let _ = tokio::task::spawn_blocking(move || {
-                                        run_remote_command(h_c, p_c, &cmd)
-                                    }).await;
+                                    let _ = run_remote_command(h_c, p_c, cmd).await;
                                     rb_c.emit_clicked();
                                 });
                             });
@@ -349,9 +345,7 @@ impl DockerManager {
                             glib::MainContext::default().spawn_local(async move {
                                 let sub_cmd = if is_c_del { "rm -f" } else { "rmi" };
                                 let cmd = format!("DOCKER_BIN=$(if [ -w /var/run/docker.sock ]; then echo 'docker'; else echo 'sudo -n docker'; fi); $DOCKER_BIN {} {}", sub_cmd, n_c);
-                                let _ = tokio::task::spawn_blocking(move || {
-                                    run_remote_command(h_c, p_c, &cmd)
-                                }).await;
+                                let _ = run_remote_command(h_c, p_c, cmd).await;
                                 rb_c.emit_clicked();
                             });
                         });
@@ -412,12 +406,10 @@ impl DockerManager {
                          echo $OUT; \
                        fi";
             
-            let result = tokio::task::spawn_blocking(move || {
-                run_remote_command(host, password, cmd)
-            }).await;
+            let result = run_remote_command(host, password, cmd.to_string()).await;
 
             match result {
-                Ok(Ok(output)) => {
+                Ok(output) => {
                     let trimmed = output.trim();
                     let last_line = trimmed.lines().last().unwrap_or("");
                     let parts: Vec<&str> = last_line.split_whitespace().collect();

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -217,11 +217,9 @@ impl SystemMonitor {
                 let h = h_clone.clone();
                 let p = p_clone.clone();
                 
-                let result = tokio::task::spawn_blocking(move || {
-                    run_remote_command(h, p, cmd)
-                }).await;
+                let result = run_remote_command(h, p, cmd.to_string()).await;
 
-                if let Ok(Ok(output)) = result {
+                if let Ok(output) = result {
                     if let Ok(mut st) = s_clone.try_borrow_mut() {
                         let mut current_section = "";
                         let mut ips = Vec::new();

--- a/src/ui/ssh_keys.rs
+++ b/src/ui/ssh_keys.rs
@@ -325,9 +325,7 @@ fn show_deploy_dialog(parent: &gtk4::ApplicationWindow, key: &SshKeyPair) {
 
                     let h_c = host.clone();
                     let pk_c = pubkey.clone();
-                    let result = tokio::task::spawn_blocking(move || {
-                        crate::ssh_engine::deploy_pubkey(&h_c, final_password, &pk_c)
-                    }).await.unwrap_or_else(|_| Err(anyhow::anyhow!("Task panic")));
+                    let result = crate::ssh_engine::deploy_pubkey(h_c, final_password, pk_c).await;
 
                     match result {
                         Ok(_) => {


### PR DESCRIPTION
This pull request refactors the SSH and SFTP connection logic to use asynchronous (async/await) Rust APIs instead of blocking calls, improving performance and responsiveness, especially in the UI. It also updates related UI and helper functions to use the new async signatures, removing unnecessary `spawn_blocking` wrappers and simplifying code.

**Core async/await migration and API changes:**

* Refactored `establish_ssh_session` in `src/ssh_engine.rs` to be fully async, using `tokio`'s async networking and DNS lookup, and moved blocking SSH session setup into `spawn_blocking` for safety. The function signature now takes an owned `Option<String>` for passwords instead of a borrowed reference. [[1]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL2-R40) [[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL43-R68)
* Updated `deploy_pubkey` and `run_remote_command` to be async functions, with their internal SSH session setup and remote command execution performed in `spawn_blocking`. Their signatures now require owned types and are awaited directly. [[1]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL43-R68) [[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eR84-R97)

**UI and usage updates:**

* Updated all UI code in `src/ui/docker.rs`, `src/ui/monitor.rs`, and `src/ui/ssh_keys.rs` to call the new async `run_remote_command` and `deploy_pubkey` functions directly, removing redundant `spawn_blocking` wrappers and adjusting for the new signatures. [[1]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L261-R263) [[2]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L325-R323) [[3]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L352-R348) [[4]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L415-R412) [[5]](diffhunk://#diff-21cfb10f45e83282020c46bf3db6774a361446bc7aa6af4d931b0bafcdae5818L220-R222) [[6]](diffhunk://#diff-4750f20168a2936759b01f845a100a3b1044258228152af5e6519aa82463a7aaL328-R328)

**SFTP connection improvements:**

* Refactored SFTP session creation in `get_or_connect_sftp` to use the new async SSH session logic and moved only the SFTP handle creation into `spawn_blocking`, reducing unnecessary thread usage.

These changes modernize the SSH/SFTP handling, improve performance, and simplify the async/UI integration.