### PR TITLE
refactor: dismantle build_ui monolith into modular components and App…

### DIFF
--- a/src/ui/components/header.rs
+++ b/src/ui/components/header.rs
@@ -1,0 +1,20 @@
+use gtk4::prelude::*;
+
+pub struct Header {
+    pub container: gtk4::HeaderBar,
+    pub add_btn: gtk4::Button,
+}
+
+impl Header {
+    pub fn new() -> Self {
+        let container = gtk4::HeaderBar::new();
+        let add_btn = gtk4::Button::from_icon_name("list-add-symbolic");
+        add_btn.add_css_class("suggested-action");
+        container.pack_start(&add_btn);
+
+        Self {
+            container,
+            add_btn,
+        }
+    }
+}

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,0 +1,3 @@
+pub mod sidebar;
+pub mod header;
+pub mod settings;

--- a/src/ui/components/settings.rs
+++ b/src/ui/components/settings.rs
@@ -1,0 +1,92 @@
+use gtk4::prelude::*;
+use crate::config_observer::AppConfig;
+
+pub struct Settings {
+    pub container: gtk4::Box,
+}
+
+impl Settings {
+    pub fn new() -> Self {
+        let config = crate::config_observer::load_app_config();
+        let container = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+        
+        let scrolled = gtk4::ScrolledWindow::builder()
+            .vexpand(true)
+            .hscrollbar_policy(gtk4::PolicyType::Never)
+            .build();
+        
+        let content = gtk4::Box::new(gtk4::Orientation::Vertical, 32);
+        content.set_margin_top(48); content.set_margin_bottom(48); content.set_margin_start(48); content.set_margin_end(48);
+        content.set_halign(gtk4::Align::Center);
+        content.set_width_request(600);
+
+        let header_box = gtk4::Box::new(gtk4::Orientation::Vertical, 8);
+        header_box.append(&gtk4::Label::builder().label("Settings").halign(gtk4::Align::Start).css_classes(vec!["title-1".to_string()]).build());
+        header_box.append(&gtk4::Label::builder().label("Configure your global preferences").halign(gtk4::Align::Start).css_classes(vec!["dim-label".to_string()]).build());
+        content.append(&header_box);
+
+        let terminal_group = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        terminal_group.append(&gtk4::Label::builder().label("Terminal").halign(gtk4::Align::Start).css_classes(vec!["title-4".to_string()]).build());
+
+        let font_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+        let font_label = gtk4::Label::new(Some("Font")); font_label.set_hexpand(true); font_label.set_halign(gtk4::Align::Start);
+        let font_button = gtk4::FontButton::with_font(&config.terminal_font);
+        font_row.append(&font_label); font_row.append(&font_button);
+        terminal_group.append(&font_row);
+
+        let scrollback_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+        let scrollback_label = gtk4::Label::new(Some("Scrollback Lines")); scrollback_label.set_hexpand(true); scrollback_label.set_halign(gtk4::Align::Start);
+        let scrollback_adj = gtk4::Adjustment::new(config.terminal_scrollback as f64, 100.0, 100000.0, 100.0, 1000.0, 0.0);
+        let scrollback_spinner = gtk4::SpinButton::new(Some(&scrollback_adj), 1.0, 0);
+        scrollback_row.append(&scrollback_label); scrollback_row.append(&scrollback_spinner);
+        terminal_group.append(&scrollback_row);
+        content.append(&terminal_group);
+
+        let monitor_group = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        monitor_group.append(&gtk4::Label::builder().label("System Monitor").halign(gtk4::Align::Start).css_classes(vec!["title-4".to_string()]).build());
+
+        let refresh_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+        let refresh_label = gtk4::Label::new(Some("Default Refresh Rate")); refresh_label.set_hexpand(true); refresh_label.set_halign(gtk4::Align::Start);
+        let refresh_dropdown = gtk4::DropDown::from_strings(&["1s", "3s", "5s", "10s"]);
+        refresh_dropdown.set_selected(config.monitor_refresh_rate);
+        refresh_row.append(&refresh_label); refresh_row.append(&refresh_dropdown);
+        monitor_group.append(&refresh_row);
+        content.append(&monitor_group);
+
+        let ui_group = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
+        ui_group.append(&gtk4::Label::builder().label("User Interface").halign(gtk4::Align::Start).css_classes(vec!["title-4".to_string()]).build());
+
+        let confirm_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
+        let confirm_label = gtk4::Label::new(Some("Confirm before closing tabs")); confirm_label.set_hexpand(true); confirm_label.set_halign(gtk4::Align::Start);
+        let confirm_switch = gtk4::Switch::new();
+        confirm_switch.set_active(config.confirm_tab_close);
+        confirm_row.append(&confirm_label); confirm_row.append(&confirm_switch);
+        ui_group.append(&confirm_row);
+        content.append(&ui_group);
+
+        let r_drop = refresh_dropdown.clone();
+        let f_btn = font_button.clone();
+        let s_spin = scrollback_spinner.clone();
+        let c_switch = confirm_switch.clone();
+
+        let save_config = move || {
+            let mut new_config = AppConfig::default();
+            new_config.monitor_refresh_rate = r_drop.selected();
+            new_config.terminal_font = f_btn.font().map(|s| s.to_string()).unwrap_or_else(|| "Monospace 11".to_string());
+            new_config.terminal_scrollback = s_spin.value() as u32;
+            new_config.confirm_tab_close = c_switch.is_active();
+            let _ = crate::config_observer::save_app_config(&new_config);
+        };
+
+        let save_fn = std::rc::Rc::new(save_config);
+        let s1 = save_fn.clone(); refresh_dropdown.connect_selected_notify(move |_| { s1(); });
+        let s2 = save_fn.clone(); font_button.connect_font_set(move |_| { s2(); });
+        let s3 = save_fn.clone(); scrollback_spinner.connect_value_changed(move |_| { s3(); });
+        let s5 = save_fn.clone(); confirm_switch.connect_active_notify(move |_| { s5(); });
+
+        scrolled.set_child(Some(&content));
+        container.append(&scrolled);
+        
+        Self { container }
+    }
+}

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -1,0 +1,46 @@
+use gtk4::prelude::*;
+
+pub struct Sidebar {
+    pub container: gtk4::Box,
+    pub btn_servers: gtk4::Button,
+    pub btn_keys: gtk4::Button,
+    pub btn_settings: gtk4::Button,
+}
+
+impl Sidebar {
+    pub fn new() -> Self {
+        let container = gtk4::Box::new(gtk4::Orientation::Vertical, 6);
+        container.set_width_request(60);
+        container.set_margin_top(12);
+
+        let btn_servers = Self::create_sidebar_button("network-transmit-receive-symbolic");
+        let btn_keys = Self::create_sidebar_button("changes-prevent-symbolic");
+        let btn_settings = Self::create_sidebar_button("applications-system-symbolic");
+        btn_settings.set_margin_bottom(12);
+
+        let spacer = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+        spacer.set_vexpand(true);
+
+        container.append(&btn_servers);
+        container.append(&btn_keys);
+        container.append(&spacer);
+        container.append(&btn_settings);
+
+        Self {
+            container,
+            btn_servers,
+            btn_keys,
+            btn_settings,
+        }
+    }
+
+    fn create_sidebar_button(icon_name: &str) -> gtk4::Button {
+        let btn = gtk4::Button::from_icon_name(icon_name);
+        btn.add_css_class("flat");
+        btn.set_halign(gtk4::Align::Center);
+        btn.set_valign(gtk4::Align::Start);
+        btn.set_width_request(36);
+        btn.set_height_request(36);
+        btn
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod hud;
 pub mod window;
 pub mod server_list;
+pub mod components;
 pub mod add_server_dialog;
 pub mod file_explorer;
 pub mod ssh_keys;

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -6,698 +6,486 @@ use crate::ui::file_explorer::FileExplorer;
 use crate::ui::monitor::SystemMonitor;
 use crate::ui::docker::DockerManager;
 use crate::ui::ssh_keys::build_ssh_keys_ui;
-use crate::config_observer::{add_host_to_config, delete_host_from_config, load_hosts};
+use crate::ui::components::sidebar::Sidebar;
+use crate::ui::components::header::Header;
+use crate::ui::components::settings::Settings;
+use crate::config_observer::{add_host_to_config, delete_host_from_config, load_hosts, SshHost};
 use vte4::prelude::*;
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::collections::HashMap;
 
-pub fn build_ui(app: &gtk4::Application) {
-    let window = gtk4::ApplicationWindow::builder()
-        .application(app)
-        .title("Rustmius")
-        .default_width(1100)
-        .default_height(800)
-        .build();
+#[derive(Clone)]
+pub struct AppWindow {
+    inner: Rc<AppWindowInner>,
+}
 
-    let root = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+struct AppWindowInner {
+    window: gtk4::ApplicationWindow,
+    stack: gtk4::Stack,
+    notebook: gtk4::Notebook,
+}
 
-    let sidebar = gtk4::Box::new(gtk4::Orientation::Vertical, 6);
-    sidebar.set_width_request(60);
-    sidebar.set_margin_top(12);
-    let btn_servers = gtk4::Button::from_icon_name("network-transmit-receive-symbolic");
-    btn_servers.add_css_class("flat");
-    btn_servers.set_halign(gtk4::Align::Center);
-    btn_servers.set_valign(gtk4::Align::Start);
-    btn_servers.set_width_request(36);
-    btn_servers.set_height_request(36);
-    let btn_keys = gtk4::Button::from_icon_name("changes-prevent-symbolic");
-    btn_keys.add_css_class("flat");
-    btn_keys.set_halign(gtk4::Align::Center);
-    btn_keys.set_valign(gtk4::Align::Start);
-    btn_keys.set_width_request(36);
-    btn_keys.set_height_request(36);
-    let spacer = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-    spacer.set_vexpand(true);
-    let btn_settings = gtk4::Button::from_icon_name("applications-system-symbolic");
-    btn_settings.add_css_class("flat");
-    btn_settings.set_halign(gtk4::Align::Center);
-    btn_settings.set_valign(gtk4::Align::Start);
-    btn_settings.set_width_request(36);
-    btn_settings.set_height_request(36);
-    btn_settings.set_margin_bottom(12);
-    sidebar.append(&btn_servers);
-    sidebar.append(&btn_keys);
-    sidebar.append(&spacer);
-    sidebar.append(&btn_settings);
+impl AppWindow {
+    pub fn new(app: &gtk4::Application) -> Self {
+        let window = gtk4::ApplicationWindow::builder()
+            .application(app)
+            .title("Rustmius")
+            .default_width(1100)
+            .default_height(800)
+            .build();
 
-    let separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
+        let root = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+        let sidebar = Sidebar::new();
+        let separator = gtk4::Separator::new(gtk4::Orientation::Vertical);
+        let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+        content_box.set_hexpand(true);
 
-    let content_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-    content_box.set_hexpand(true);
-    let header = gtk4::HeaderBar::new();
-    let add_btn = gtk4::Button::from_icon_name("list-add-symbolic");
-    add_btn.add_css_class("suggested-action");
-    header.pack_start(&add_btn);
-    window.set_titlebar(Some(&header));
+        let header = Header::new();
+        window.set_titlebar(Some(&header.container));
 
-    let stack = gtk4::Stack::new();
-    stack.set_transition_type(gtk4::StackTransitionType::Crossfade);
-    content_box.append(&stack);
+        let stack = gtk4::Stack::new();
+        stack.set_transition_type(gtk4::StackTransitionType::Crossfade);
+        content_box.append(&stack);
 
-    let notebook = gtk4::Notebook::new();
-    notebook.set_vexpand(true);
-    notebook.set_hexpand(true);
-    notebook.set_scrollable(true);
-    notebook.set_show_border(false);
-    let sessions_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-    sessions_box.append(&notebook);
-    stack.add_named(&sessions_box, Some("sessions"));
+        let notebook = gtk4::Notebook::new();
+        notebook.set_vexpand(true);
+        notebook.set_hexpand(true);
+        notebook.set_scrollable(true);
+        notebook.set_show_border(false);
+        
+        let sessions_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+        sessions_box.append(&notebook);
+        stack.add_named(&sessions_box, Some("sessions"));
 
-    let last_session_page = Rc::new(RefCell::new(0u32));
+        let settings = Settings::new();
+        stack.add_named(&settings.container, Some("settings"));
 
-    let last_pg = last_session_page.clone();
+        let keys_box = build_ssh_keys_ui(&window);
+        stack.add_named(&keys_box, Some("ssh_keys"));
 
-    let refresh_ui: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
-    let stack_clone = stack.clone();
-    let window_clone = window.clone();
-    let notebook_clone = notebook.clone();
-    let refresh_ui_weak = Rc::downgrade(&refresh_ui);
+        root.append(&sidebar.container);
+        root.append(&separator);
+        root.append(&content_box);
+        window.set_child(Some(&root));
 
-    notebook.connect_switch_page(move |nb, _, _| {
-        *last_pg.borrow_mut() = nb.current_page().unwrap_or(0);
-    });
+        let app_window = Self {
+            inner: Rc::new(AppWindowInner {
+                window,
+                stack,
+                notebook,
+            }),
+        };
 
-    notebook.connect_page_reordered(|nb, child, page_num| {
-        if page_num == 0 && child.widget_name() != "server_list_tab" {
-            nb.reorder_child(child, Some(1));
-        }
-    });
+        app_window.setup_callbacks(sidebar, header);
+        app_window.refresh();
+        app_window.inner.window.present();
+        app_window
+    }
 
-    let do_refresh = {
-        let sc = stack_clone.clone();
-        let wc = window_clone.clone();
-        let nc = notebook_clone.clone();
-        let rwh = refresh_ui_weak.clone();
-        Rc::new(move || {
-            let stack = sc.clone();
-            let window = wc.clone();
-            let notebook = nc.clone();
-            let refresh_ui_handle = rwh.upgrade().unwrap();
-            let sl_stack = stack.clone();
-            let sl_window = window.clone();
-            let sl_notebook = notebook.clone();
-            let sl_refresh_handle = refresh_ui_handle.clone();
+    fn setup_callbacks(&self, sidebar: Sidebar, header: Header) {
+        let this = self.clone();
+        sidebar.btn_servers.connect_clicked(move |_| {
+            this.show_sessions();
+        });
 
-        let sl = ServerList::new(move |action| {
-            let stack = sl_stack.clone();
-            let window = sl_window.clone();
-            let notebook = sl_notebook.clone();
-            let refresh = sl_refresh_handle.borrow().as_ref().unwrap().clone();
-            match action {
-                ServerAction::Connect(host, password) => {
-                    stack.set_visible_child_name("sessions");
-                    let session_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-                    let toolbar = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
-                    toolbar.set_margin_top(4);
-                    toolbar.set_margin_bottom(4);
-                    toolbar.set_margin_start(6);
-                    let explorer_btn = gtk4::Button::from_icon_name("folder-remote-symbolic");
-                    explorer_btn.add_css_class("flat");
-                    explorer_btn.set_tooltip_text(Some("File Explorer"));
+        let this = self.clone();
+        sidebar.btn_keys.connect_clicked(move |_| {
+            this.inner.stack.set_visible_child_name("ssh_keys");
+        });
 
-                    let monitor_btn = gtk4::Button::from_icon_name("utilities-system-monitor-symbolic");
-                    monitor_btn.add_css_class("flat");
-                    monitor_btn.set_tooltip_text(Some("System Monitor"));
+        let this = self.clone();
+        sidebar.btn_settings.connect_clicked(move |_| {
+            this.inner.stack.set_visible_child_name("settings");
+        });
 
-                    let docker_btn = gtk4::Button::new();
-                    docker_btn.set_child(Some(&crate::ui::get_docker_icon()));
-                    docker_btn.add_css_class("flat");
-                    docker_btn.set_tooltip_text(Some("Docker Management"));
+        let this = self.clone();
+        header.add_btn.connect_clicked(move |_| {
+            this.show_add_server_dialog();
+        });
 
-                    let host_docker = host.clone();
-                    let pass_docker = password.clone();
-                    let nb_docker = notebook.clone();
-                    docker_btn.connect_clicked(move |_| {
-                        let docker = DockerManager::new(host_docker.clone(), pass_docker.clone());
-                        let label_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 4);
-                        label_box.append(&crate::ui::get_docker_icon());
-                        label_box.append(&gtk4::Label::new(Some(&format!("Docker: {}", host_docker.alias))));                        let close_btn = gtk4::Button::from_icon_name("window-close-symbolic");
-                        close_btn.add_css_class("flat");
-                        label_box.append(&close_btn);
-                        
-                        let page_idx = nb_docker.append_page(&docker.container, Some(&label_box));
-                        nb_docker.set_tab_reorderable(&docker.container, true);
-                        nb_docker.set_current_page(Some(page_idx));
-
-                        let nb_close = nb_docker.clone();
-                        let child_close = docker.container.clone();
-                        close_btn.connect_clicked(move |_| {
-                            let idx = nb_close.page_num(&child_close);
-                            nb_close.remove_page(idx);
-                        });
-                    });
-
-                    toolbar.append(&explorer_btn);
-                    toolbar.append(&monitor_btn);
-                    toolbar.append(&docker_btn);
-                    session_box.append(&toolbar);
-
-                    let terminal = vte4::Terminal::new();
-                    terminal.set_vexpand(true);
-                    
-                    let app_config = crate::config_observer::load_app_config();
-                    let font_desc = gtk4::pango::FontDescription::from_string(&app_config.terminal_font);
-                    terminal.set_font(Some(&font_desc));
-                    terminal.set_scrollback_lines(app_config.terminal_scrollback as i64);
-
-                    let key_controller = gtk4::EventControllerKey::new();
-                    let terminal_clone = terminal.clone();
-                    key_controller.connect_key_pressed(move |_controller, keyval, _keycode, state| {
-                        let is_ctrl = state.contains(gdk::ModifierType::CONTROL_MASK);
-                        let is_shift = state.contains(gdk::ModifierType::SHIFT_MASK);
-
-                        if is_ctrl && is_shift {
-                            match keyval {
-                                gdk::Key::C => {
-                                    terminal_clone.copy_clipboard_format(vte4::Format::Text);
-                                    glib::Propagation::Stop
-                                }
-                                gdk::Key::V => {
-                                    terminal_clone.paste_clipboard();
-                                    glib::Propagation::Stop
-                                }
-                                _ => glib::Propagation::Proceed,
-                            }
-                        } else {
-                            glib::Propagation::Proceed
-                        }
-                    });
-                    terminal.add_controller(key_controller);
-
-                    session_box.append(&terminal);
-
-                    let mut count = 0;
-                    for i in 0..notebook.n_pages() {
-                        if let Some(p) = notebook.nth_page(Some(i))
-                            && p.widget_name().starts_with(&format!("session:{}", host.alias)) {
-                                count += 1;
-                            }
-                    }
-                    session_box.set_widget_name(&format!("session:{}:{}", host.alias, count));
-
-                    let display_name = if count > 0 { format!("{} ({})", host.alias, count) } else { host.alias.clone() };
-                    let tab_label_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
-                    let label = gtk4::Label::new(Some(&display_name));
-                    let close_btn = gtk4::Button::from_icon_name("window-close-symbolic");
-                    close_btn.add_css_class("flat");
-                    tab_label_box.append(&label);
-                    tab_label_box.append(&close_btn);
-                    let mut insert_pos = notebook.n_pages();
-                    for i in 0..notebook.n_pages() {
-                        if let Some(c) = notebook.nth_page(Some(i))
-                            && c.widget_name() == "plus_tab_dummy" { insert_pos = i; break; }
-                    }
-                    notebook.insert_page(&session_box, Some(&tab_label_box), Some(insert_pos));
-                    notebook.set_tab_reorderable(&session_box, true);
-                    notebook.set_current_page(Some(insert_pos));
-                    let nb_close = notebook.clone();
-                    let sb_close = session_box.clone();
-                    let win_ref = window.clone();
-
-                    let close_gesture = gtk4::GestureClick::new();
-                    close_gesture.connect_pressed(move |gesture, _, _, _| {
-                        gesture.set_state(gtk4::EventSequenceState::Claimed);
-                        
-                        let nb = nb_close.clone();
-                        let sb = sb_close.clone();
-                        let win = win_ref.clone();
-
-                        let on_confirm = move || {
-                            let idx = nb.page_num(&sb);
-                            if let Some(i) = idx {
-                                let current = nb.current_page();
-                                if current == Some(i) && nb.n_pages() > 2 {
-                                    let target = if i > 0 { i - 1 } else { 1 };
-                                    nb.set_current_page(Some(target));
-                                }
-                                nb.remove_page(Some(i));
-                            }
-                        };
-
-                        let app_config = crate::config_observer::load_app_config();
-                        if app_config.confirm_tab_close {
-                            show_close_confirmation(&win, "Close Tab?", "Are you sure you want to close this session?", on_confirm);
-                        } else {
-                            on_confirm();
-                        }
-                    });
-                    close_btn.add_controller(close_gesture);
-
-                    let nb_exp = notebook.clone();
-                    let host_exp = host.clone();
-                    let win_exp = window.clone();
-                    explorer_btn.connect_clicked(move |_| {
-                        let h_exp = host_exp.clone();
-                        let h_alias = h_exp.alias.clone();
-                        let nb_spawn = nb_exp.clone();
-                        let window = win_exp.clone();
-
-                        glib::MainContext::default().spawn_local(async move {
-                            let mut password = None;
-                            if let Ok(keyring) = oo7::Keyring::new().await {
-                                let mut attr = std::collections::HashMap::new();
-                                let alias_lower = h_alias.to_lowercase();
-                                attr.insert("rustmius-server-alias", alias_lower.as_str());
-                                if let Ok(items) = keyring.search_items(&attr).await
-                                    && let Some(item) = items.first()
-                                        && let Ok(pass) = item.secret().await {
-                                            password = std::str::from_utf8(pass.as_ref()).map(String::from).ok();
-                                        }
-                            }
-
-                            let explorer = FileExplorer::new(h_exp, password);
-
-                            let mut count = 0;
-                            for i in 0..nb_spawn.n_pages() {
-                                if let Some(p) = nb_spawn.nth_page(Some(i))
-                                    && p.widget_name().starts_with(&format!("explorer:{}", h_alias)) {
-                                        count += 1;
-                                    }
-                            }
-                            explorer.container.set_widget_name(&format!("explorer:{}:{}", h_alias, count));
-
-                            let display_name = if count > 0 { format!("📁 {} ({})", h_alias, count) } else { format!("📁 {}", h_alias) };
-                            let exp_tab_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
-                            exp_tab_box.append(&gtk4::Label::new(Some(&display_name)));
-                            let exp_close = gtk4::Button::from_icon_name("window-close-symbolic");
-                            exp_close.add_css_class("flat");
-                            exp_tab_box.append(&exp_close);
-
-                            let mut ins_pos = nb_spawn.n_pages();
-                            for i in 0..nb_spawn.n_pages() {
-                                if let Some(c) = nb_spawn.nth_page(Some(i))
-                                    && c.widget_name() == "plus_tab_dummy" { ins_pos = i; break; }
-                            }
-                            nb_spawn.insert_page(&explorer.container, Some(&exp_tab_box), Some(ins_pos));
-                            nb_spawn.set_tab_reorderable(&explorer.container, true);
-                            nb_spawn.set_current_page(Some(ins_pos));
-
-                            let nb_c = nb_spawn.clone();
-                            let ex_c = explorer.container.clone();
-                            let win_c = window.clone();
-
-                            let exp_close_gesture = gtk4::GestureClick::new();
-                            exp_close_gesture.connect_pressed(move |gesture, _, _, _| {
-                                gesture.set_state(gtk4::EventSequenceState::Claimed);
-                                let nb = nb_c.clone();
-                                let ex = ex_c.clone();
-                                let win = win_c.clone();
-
-                                let on_confirm = move || {
-                                    let idx = nb.page_num(&ex);
-                                    if let Some(i) = idx {
-                                        let current = nb.current_page();
-                                        if current == Some(i) && nb.n_pages() > 2 {
-                                            let target = if i > 0 { i - 1 } else { 1 };
-                                            nb.set_current_page(Some(target));
-                                        }
-                                        nb.remove_page(Some(i));
-                                    }
-                                };
-
-                                let app_config = crate::config_observer::load_app_config();
-                                if app_config.confirm_tab_close {
-                                    show_close_confirmation(&win, "Close Explorer?", "Are you sure you want to close this explorer tab?", on_confirm);
-                                } else {
-                                    on_confirm();
-                                }
-                            });
-                            exp_close.add_controller(exp_close_gesture);
-                        });
-                    });
-
-                    let nb_mon = notebook.clone();
-                    let host_mon = host.clone();
-                    let win_mon = window.clone();
-                    monitor_btn.connect_clicked(move |_| {
-                        let h_mon = host_mon.clone();
-                        let h_alias = h_mon.alias.clone();
-                        let nb_spawn = nb_mon.clone();
-                        let window = win_mon.clone();
-
-                        glib::MainContext::default().spawn_local(async move {
-                            let mut password = None;
-                            if let Ok(keyring) = oo7::Keyring::new().await {
-                                let mut attr = std::collections::HashMap::new();
-                                let alias_lower = h_alias.to_lowercase();
-                                attr.insert("rustmius-server-alias", alias_lower.as_str());
-                                if let Ok(items) = keyring.search_items(&attr).await
-                                    && let Some(item) = items.first()
-                                        && let Ok(pass) = item.secret().await {
-                                            password = std::str::from_utf8(pass.as_ref()).map(String::from).ok();
-                                        }
-                            }
-
-                            let monitor = SystemMonitor::new(h_mon, password);
-
-                            let mut count = 0;
-                            for i in 0..nb_spawn.n_pages() {
-                                if let Some(p) = nb_spawn.nth_page(Some(i))
-                                    && p.widget_name().starts_with(&format!("monitor:{}", h_alias)) {
-                                        count += 1;
-                                    }
-                            }
-                            monitor.container.set_widget_name(&format!("monitor:{}:{}", h_alias, count));
-
-                            let display_name = if count > 0 { format!("📈 {} ({})", h_alias, count) } else { format!("📈 {}", h_alias) };
-                            let mon_tab_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
-                            mon_tab_box.append(&gtk4::Label::new(Some(&display_name)));
-                            let mon_close = gtk4::Button::from_icon_name("window-close-symbolic");
-                            mon_close.add_css_class("flat");
-                            mon_tab_box.append(&mon_close);
-
-                            let mut ins_pos = nb_spawn.n_pages();
-                            for i in 0..nb_spawn.n_pages() {
-                                if let Some(c) = nb_spawn.nth_page(Some(i))
-                                    && c.widget_name() == "plus_tab_dummy" { ins_pos = i; break; }
-                            }
-                            nb_spawn.insert_page(&monitor.container, Some(&mon_tab_box), Some(ins_pos));
-                            nb_spawn.set_tab_reorderable(&monitor.container, true);
-                            nb_spawn.set_current_page(Some(ins_pos));
-
-                            let nb_c = nb_spawn.clone();
-                            let mo_c = monitor.container.clone();
-                            let win_c = window.clone();
-
-                            let mon_close_gesture = gtk4::GestureClick::new();
-                            mon_close_gesture.connect_pressed(move |gesture, _, _, _| {
-                                gesture.set_state(gtk4::EventSequenceState::Claimed);
-                                let nb = nb_c.clone();
-                                let mo = mo_c.clone();
-                                let win = win_c.clone();
-
-                                let on_confirm = move || {
-                                    let idx = nb.page_num(&mo);
-                                    if let Some(i) = idx {
-                                        let current = nb.current_page();
-                                        if current == Some(i) && nb.n_pages() > 2 {
-                                            let target = if i > 0 { i - 1 } else { 1 };
-                                            nb.set_current_page(Some(target));
-                                        }
-                                        nb.remove_page(Some(i));
-                                    }
-                                };
-
-                                let app_config = crate::config_observer::load_app_config();
-                                if app_config.confirm_tab_close {
-                                    show_close_confirmation(&win, "Close Monitor?", "Are you sure you want to close this monitoring tab?", on_confirm);
-                                } else {
-                                    on_confirm();
-                                }
-                            });
-                            mon_close.add_controller(mon_close_gesture);
-                        });
-                    });
-
-                    let host_str = host.hostname.clone();
-                    let user_str = host.user.clone().unwrap_or_else(|| "root".to_string());
-                    let host_alias = host.alias.clone();
-                    let exe_path = std::env::current_exe().unwrap_or_default().to_string_lossy().to_string();
-                    let mut envv: Vec<String> = std::env::vars().map(|(k, v)| format!("{}={}", k, v)).collect();
-                    if host.identity_file.is_none() {
-                        envv.push(format!("SSH_ASKPASS={}", exe_path));
-                        envv.push("SSH_ASKPASS_REQUIRE=force".to_string());
-                        envv.push(format!("RUSTMIUS_ASKPASS_ALIAS={}", host_alias));
-                    }
-                    envv.push("DISPLAY=:0".to_string());
-                    let env_refs: Vec<&str> = envv.iter().map(|s| s.as_str()).collect();
-                    let port_str = host.port.unwrap_or(22).to_string();
-                    let mut ssh_args = vec![
-                        "/usr/bin/ssh".to_string(),
-                        "-p".to_string(),
-                        port_str,
-                        "-o".to_string(),
-                        "StrictHostKeyChecking=no".to_string(),
-                    ];
-                    if let Some(identity_file) = &host.identity_file {
-                        ssh_args.push("-i".to_string());
-                        ssh_args.push(identity_file.clone());
-                    }
-                    ssh_args.push(format!("{}@{}", user_str, host_str));
-                    let ssh_args_refs: Vec<&str> = ssh_args.iter().map(|s| s.as_str()).collect();
-
-                    terminal.spawn_async(vte4::PtyFlags::DEFAULT, None, &ssh_args_refs, &env_refs, glib::SpawnFlags::SEARCH_PATH, || {}, -1, None::<&gio::Cancellable>, |_| {});
-                },
-                ServerAction::Delete(host) => {
-                    let _ = delete_host_from_config(&host.alias);
-                    let alias_norm = host.alias.to_lowercase();
-                    glib::MainContext::default().spawn_local(async move {
-                        if let Ok(keyring) = oo7::Keyring::new().await {
-                            let mut attr = std::collections::HashMap::new();
-                            attr.insert("rustmius-server-alias", alias_norm.as_str());
-                            if let Ok(items) = keyring.search_items(&attr).await { for item in items { let _ = item.delete().await; } }
-                        }
-                    });
-                    refresh();
-                },
-                ServerAction::Edit(host) => {
-                    let host_to_edit = host.clone();
-                    let old_alias = host.alias.clone();
-                    let refresh_edit = refresh.clone();
-                    let existing_aliases: Vec<String> = load_hosts().into_iter().map(|h| h.alias.to_lowercase()).collect();
-                    show_server_dialog(window.upcast_ref(), Some(&host_to_edit), existing_aliases, move |new_host, password| {
-                        let _ = delete_host_from_config(&old_alias);
-                        if let Ok(_) = add_host_to_config(&new_host) {
-                            if !password.is_empty() {
-                                let host_alias = new_host.alias.clone();
-                                glib::MainContext::default().spawn_local(async move {
-                                    if let Ok(keyring) = oo7::Keyring::new().await {
-                                        let mut attr = std::collections::HashMap::new();
-                                        let alias_lower = host_alias.to_lowercase();
-                                        attr.insert("rustmius-server-alias", alias_lower.as_str());
-                                        let _ = keyring.create_item(&format!("Rustmius: SSH Password for {}", host_alias), &attr, password.as_bytes(), true).await;
-                                    }
-                                });
-                            }
-                            refresh_edit();
-                        }
-                    });
-                }
+        self.inner.notebook.connect_page_reordered(|nb, child, page_num| {
+            if page_num == 0 && child.widget_name() != "server_list_tab" {
+                nb.reorder_child(child, Some(1));
             }
         });
-        let mut server_list_idx = None;
-        for i in 0..notebook.n_pages() {
-            if let Some(c) = notebook.nth_page(Some(i))
-                && c.widget_name() == "server_list_tab" { server_list_idx = Some(i); break; }
-        }
-        sl.container.set_widget_name("server_list_tab");
-        let tab_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
-        tab_box.append(&gtk4::Image::from_icon_name("view-grid-symbolic"));
-        tab_box.append(&gtk4::Label::new(Some("Connect")));
-        if let Some(idx) = server_list_idx {
-            notebook.remove_page(Some(idx));
-            notebook.insert_page(&sl.container, Some(&tab_box), Some(idx));
-        } else {
-            notebook.insert_page(&sl.container, Some(&tab_box), Some(0));
-            notebook.set_current_page(Some(0));
-        }
-        notebook.set_tab_reorderable(&sl.container, false);
+    }
 
-        })
-    };
-
-    *refresh_ui.borrow_mut() = Some(do_refresh.clone());
-    do_refresh();
-
-    let stack_sessions = stack.clone();
-    let nb_sessions = notebook.clone();
-    btn_servers.connect_clicked(move |_| {
+    fn show_sessions(&self) {
         let mut sl_idx = None;
-        for i in 0..nb_sessions.n_pages() {
-            if let Some(c) = nb_sessions.nth_page(Some(i))
+        for i in 0..self.inner.notebook.n_pages() {
+            if let Some(c) = self.inner.notebook.nth_page(Some(i))
                 && c.widget_name() == "server_list_tab" { sl_idx = Some(i); break; }
         }
         if let Some(idx) = sl_idx {
-            nb_sessions.set_current_page(Some(idx));
+            self.inner.notebook.set_current_page(Some(idx));
         } else {
-            let refresh_h = refresh_ui_weak.upgrade().unwrap();
-            if let Some(r) = refresh_h.borrow().as_ref() { r(); }
+            self.refresh();
         }
-        stack_sessions.set_visible_child_name("sessions");
-    });
+        self.inner.stack.set_visible_child_name("sessions");
+    }
 
-    let stack_nav_keys = stack.clone();
-    btn_keys.connect_clicked(move |_| { stack_nav_keys.set_visible_child_name("ssh_keys"); });
-    let stack_nav_settings = stack.clone();
-    btn_settings.connect_clicked(move |_| { stack_nav_settings.set_visible_child_name("settings"); });
-
-    let keys_box = build_ssh_keys_ui(&window);
-    stack.add_named(&keys_box, Some("ssh_keys"));
-
-    let settings_box = build_settings_ui(&window);
-    stack.add_named(&settings_box, Some("settings"));
-
-    let window_add = window.clone();
-    let refresh_add = do_refresh.clone();
-    add_btn.connect_clicked(move |_| {
-        let refresh = refresh_add.clone();
+    fn show_add_server_dialog(&self) {
+        let this = self.clone();
         let existing_hosts = load_hosts();
         let existing_aliases: Vec<String> = existing_hosts.iter().map(|h| h.alias.to_lowercase()).collect();
-        show_server_dialog(window_add.upcast_ref(), None, existing_aliases, move |new_host, password| {
+        
+        show_server_dialog(self.inner.window.upcast_ref(), None, existing_aliases, move |new_host, password| {
             if let Ok(_) = add_host_to_config(&new_host) {
                 if !password.is_empty() {
                     let host_alias = new_host.alias.clone();
                     glib::MainContext::default().spawn_local(async move {
                         if let Ok(keyring) = oo7::Keyring::new().await {
-                            let mut attr = std::collections::HashMap::new();
+                            let mut attr = HashMap::new();
                             let alias_lower = host_alias.to_lowercase();
                             attr.insert("rustmius-server-alias", alias_lower.as_str());
                             let _ = keyring.create_item(&format!("Rustmius: SSH Password for {}", host_alias), &attr, password.as_bytes(), true).await;
                         }
                     });
                 }
-                refresh();
+                this.refresh();
             }
         });
-    });
+    }
 
-    root.append(&sidebar); root.append(&separator); root.append(&content_box);
-    window.set_child(Some(&root)); window.present();
-}
+    pub fn refresh(&self) {
+        let this = self.clone();
+        let sl = ServerList::new(move |action| {
+            match action {
+                ServerAction::Connect(host, password) => this.connect_to_server(host, password),
+                ServerAction::Delete(host) => this.delete_server(host),
+                ServerAction::Edit(host) => this.edit_server(host),
+            }
+        });
 
-fn build_settings_ui(parent_window: &gtk4::ApplicationWindow) -> gtk4::Box {
-    let config = crate::config_observer::load_app_config();
-    let container = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-    
-    let scrolled = gtk4::ScrolledWindow::builder()
-        .vexpand(true)
-        .hscrollbar_policy(gtk4::PolicyType::Never)
-        .build();
-    
-    let content = gtk4::Box::new(gtk4::Orientation::Vertical, 32);
-    content.set_margin_top(48);
-    content.set_margin_bottom(48);
-    content.set_margin_start(48);
-    content.set_margin_end(48);
-    content.set_halign(gtk4::Align::Center);
-    content.set_width_request(600);
+        let mut server_list_idx = None;
+        for i in 0..self.inner.notebook.n_pages() {
+            if let Some(c) = self.inner.notebook.nth_page(Some(i))
+                && c.widget_name() == "server_list_tab" { server_list_idx = Some(i); break; }
+        }
 
-    let header_box = gtk4::Box::new(gtk4::Orientation::Vertical, 8);
-    let title = gtk4::Label::builder()
-        .label("Settings")
-        .halign(gtk4::Align::Start)
-        .css_classes(vec!["title-1".to_string()])
-        .build();
-    let subtitle = gtk4::Label::builder()
-        .label("Configure your global preferences")
-        .halign(gtk4::Align::Start)
-        .css_classes(vec!["dim-label".to_string()])
-        .build();
-    header_box.append(&title);
-    header_box.append(&subtitle);
-    content.append(&header_box);
+        sl.container.set_widget_name("server_list_tab");
+        let tab_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+        tab_box.append(&gtk4::Image::from_icon_name("view-grid-symbolic"));
+        tab_box.append(&gtk4::Label::new(Some("Connect")));
 
-    let terminal_group = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
-    let terminal_title = gtk4::Label::builder()
-        .label("Terminal")
-        .halign(gtk4::Align::Start)
-        .css_classes(vec!["title-4".to_string()])
-        .build();
-    terminal_group.append(&terminal_title);
+        if let Some(idx) = server_list_idx {
+            self.inner.notebook.remove_page(Some(idx));
+            self.inner.notebook.insert_page(&sl.container, Some(&tab_box), Some(idx));
+        } else {
+            self.inner.notebook.insert_page(&sl.container, Some(&tab_box), Some(0));
+            self.inner.notebook.set_current_page(Some(0));
+        }
+        self.inner.notebook.set_tab_reorderable(&sl.container, false);
+    }
 
-    let font_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
-    let font_label = gtk4::Label::new(Some("Font"));
-    font_label.set_hexpand(true);
-    font_label.set_halign(gtk4::Align::Start);
-    let font_button = gtk4::FontButton::with_font(&config.terminal_font);
-    font_row.append(&font_label);
-    font_row.append(&font_button);
-    terminal_group.append(&font_row);
+    fn connect_to_server(&self, host: SshHost, password: Option<String>) {
+        self.inner.stack.set_visible_child_name("sessions");
+        let session_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+        let toolbar = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+        toolbar.set_margin_top(4); toolbar.set_margin_bottom(4); toolbar.set_margin_start(6);
 
-    let scrollback_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
-    let scrollback_label = gtk4::Label::new(Some("Scrollback Lines"));
-    scrollback_label.set_hexpand(true);
-    scrollback_label.set_halign(gtk4::Align::Start);
-    let scrollback_adj = gtk4::Adjustment::new(config.terminal_scrollback as f64, 100.0, 100000.0, 100.0, 1000.0, 0.0);
-    let scrollback_spinner = gtk4::SpinButton::new(Some(&scrollback_adj), 1.0, 0);
-    scrollback_row.append(&scrollback_label);
-    scrollback_row.append(&scrollback_spinner);
-    terminal_group.append(&scrollback_row);
-    content.append(&terminal_group);
+        let explorer_btn = gtk4::Button::from_icon_name("folder-remote-symbolic");
+        explorer_btn.add_css_class("flat");
+        explorer_btn.set_tooltip_text(Some("File Explorer"));
 
-    let monitor_group = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
-    let monitor_title = gtk4::Label::builder()
-        .label("System Monitor")
-        .halign(gtk4::Align::Start)
-        .css_classes(vec!["title-4".to_string()])
-        .build();
-    monitor_group.append(&monitor_title);
+        let monitor_btn = gtk4::Button::from_icon_name("utilities-system-monitor-symbolic");
+        monitor_btn.add_css_class("flat");
+        monitor_btn.set_tooltip_text(Some("System Monitor"));
 
-    let refresh_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
-    let refresh_label = gtk4::Label::new(Some("Default Refresh Rate"));
-    refresh_label.set_hexpand(true);
-    refresh_label.set_halign(gtk4::Align::Start);
-    let refresh_dropdown = gtk4::DropDown::from_strings(&["1s", "3s", "5s", "10s"]);
-    refresh_dropdown.set_selected(config.monitor_refresh_rate);
-    refresh_row.append(&refresh_label);
-    refresh_row.append(&refresh_dropdown);
-    monitor_group.append(&refresh_row);
-    content.append(&monitor_group);
+        let docker_btn = gtk4::Button::new();
+        docker_btn.set_child(Some(&crate::ui::get_docker_icon()));
+        docker_btn.add_css_class("flat");
+        docker_btn.set_tooltip_text(Some("Docker Management"));
 
-    let ui_group = gtk4::Box::new(gtk4::Orientation::Vertical, 12);
-    let ui_title = gtk4::Label::builder()
-        .label("User Interface")
-        .halign(gtk4::Align::Start)
-        .css_classes(vec!["title-4".to_string()])
-        .build();
-    ui_group.append(&ui_title);
+        toolbar.append(&explorer_btn);
+        toolbar.append(&monitor_btn);
+        toolbar.append(&docker_btn);
+        session_box.append(&toolbar);
 
-    let confirm_row = gtk4::Box::new(gtk4::Orientation::Horizontal, 12);
-    let confirm_label = gtk4::Label::new(Some("Confirm before closing tabs"));
-    confirm_label.set_hexpand(true);
-    confirm_label.set_halign(gtk4::Align::Start);
-    let confirm_switch = gtk4::Switch::new();
-    confirm_switch.set_active(config.confirm_tab_close);
-    confirm_row.append(&confirm_label);
-    confirm_row.append(&confirm_switch);
-    ui_group.append(&confirm_row);
-    content.append(&ui_group);
+        let terminal = vte4::Terminal::new();
+        terminal.set_vexpand(true);
+        let app_config = crate::config_observer::load_app_config();
+        let font_desc = gtk4::pango::FontDescription::from_string(&app_config.terminal_font);
+        terminal.set_font(Some(&font_desc));
+        terminal.set_scrollback_lines(app_config.terminal_scrollback as i64);
 
-    let r_drop = refresh_dropdown.clone();
-    let f_btn = font_button.clone();
-    let s_spin = scrollback_spinner.clone();
-    let c_switch = confirm_switch.clone();
+        let key_controller = gtk4::EventControllerKey::new();
+        let terminal_clone = terminal.clone();
+        key_controller.connect_key_pressed(move |_, keyval, _, state| {
+            let is_ctrl = state.contains(gdk::ModifierType::CONTROL_MASK);
+            let is_shift = state.contains(gdk::ModifierType::SHIFT_MASK);
+            if is_ctrl && is_shift {
+                match keyval {
+                    gdk::Key::C => { terminal_clone.copy_clipboard_format(vte4::Format::Text); glib::Propagation::Stop }
+                    gdk::Key::V => { terminal_clone.paste_clipboard(); glib::Propagation::Stop }
+                    _ => glib::Propagation::Proceed,
+                }
+            } else { glib::Propagation::Proceed }
+        });
+        terminal.add_controller(key_controller);
+        session_box.append(&terminal);
 
-    let save_config = move || {
-        let mut new_config = crate::config_observer::AppConfig::default();
-        new_config.monitor_refresh_rate = r_drop.selected();
-        new_config.terminal_font = f_btn.font().map(|s| s.to_string()).unwrap_or_else(|| "Monospace 11".to_string());
-        new_config.terminal_scrollback = s_spin.value() as u32;
-        new_config.confirm_tab_close = c_switch.is_active();
+        let mut count = 0;
+        for i in 0..self.inner.notebook.n_pages() {
+            if let Some(p) = self.inner.notebook.nth_page(Some(i))
+                && p.widget_name().starts_with(&format!("session:{}", host.alias)) { count += 1; }
+        }
+        session_box.set_widget_name(&format!("session:{}:{}", host.alias, count));
+
+        let display_name = if count > 0 { format!("{} ({})", host.alias, count) } else { host.alias.clone() };
+        let tab_label_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+        let label = gtk4::Label::new(Some(&display_name));
+        let close_btn = gtk4::Button::from_icon_name("window-close-symbolic");
+        close_btn.add_css_class("flat");
+        tab_label_box.append(&label);
+        tab_label_box.append(&close_btn);
+
+        let mut insert_pos = self.inner.notebook.n_pages();
+        for i in 0..self.inner.notebook.n_pages() {
+            if let Some(c) = self.inner.notebook.nth_page(Some(i))
+                && c.widget_name() == "plus_tab_dummy" { insert_pos = i; break; }
+        }
+        self.inner.notebook.insert_page(&session_box, Some(&tab_label_box), Some(insert_pos));
+        self.inner.notebook.set_tab_reorderable(&session_box, true);
+        self.inner.notebook.set_current_page(Some(insert_pos));
+
+        let notebook = self.inner.notebook.clone();
+        let win = self.inner.window.clone();
+        close_btn.connect_clicked(move |_| {
+            let nb = notebook.clone();
+            let sb = session_box.clone();
+            let w = win.clone();
+            let on_confirm = move || {
+                if let Some(i) = nb.page_num(&sb) {
+                    nb.remove_page(Some(i));
+                }
+            };
+            if crate::config_observer::load_app_config().confirm_tab_close {
+                show_close_confirmation(w.upcast_ref(), "Close Tab?", "Are you sure you want to close this session?", on_confirm);
+            } else { on_confirm(); }
+        });
+
+        let notebook_exp = self.inner.notebook.clone();
+        let win_exp = self.inner.window.clone();
+        let host_exp = host.clone();
+        explorer_btn.connect_clicked(move |_| {
+            Self::spawn_explorer(&notebook_exp, &win_exp, host_exp.clone());
+        });
+
+        let notebook_mon = self.inner.notebook.clone();
+        let win_mon = self.inner.window.clone();
+        let host_mon = host.clone();
+        monitor_btn.connect_clicked(move |_| {
+            Self::spawn_monitor(&notebook_mon, &win_mon, host_mon.clone());
+        });
+
+        let notebook_docker = self.inner.notebook.clone();
+        let host_docker = host.clone();
+        let pass_docker = password.clone();
+        docker_btn.connect_clicked(move |_| {
+            Self::spawn_docker(&notebook_docker, host_docker.clone(), pass_docker.clone());
+        });
+
+        self.spawn_ssh_process(&terminal, &host);
+    }
+
+    fn spawn_ssh_process(&self, terminal: &vte4::Terminal, host: &SshHost) {
+        let host_str = host.hostname.clone();
+        let user_str = host.user.clone().unwrap_or_else(|| "root".to_string());
+        let host_alias = host.alias.clone();
+        let exe_path = std::env::current_exe().unwrap_or_default().to_string_lossy().to_string();
+        let mut envv: Vec<String> = std::env::vars().map(|(k, v)| format!("{}={}", k, v)).collect();
+        if host.identity_file.is_none() {
+            envv.push(format!("SSH_ASKPASS={}", exe_path));
+            envv.push("SSH_ASKPASS_REQUIRE=force".to_string());
+            envv.push(format!("RUSTMIUS_ASKPASS_ALIAS={}", host_alias));
+        }
+        envv.push("DISPLAY=:0".to_string());
+        let env_refs: Vec<&str> = envv.iter().map(|s| s.as_str()).collect();
+        let port_str = host.port.unwrap_or(22).to_string();
+        let mut ssh_args = vec!["/usr/bin/ssh".to_string(), "-p".to_string(), port_str, "-o".to_string(), "StrictHostKeyChecking=no".to_string()];
+        if let Some(identity_file) = &host.identity_file {
+            ssh_args.push("-i".to_string()); ssh_args.push(identity_file.clone());
+        }
+        ssh_args.push(format!("{}@{}", user_str, host_str));
+        let ssh_args_refs: Vec<&str> = ssh_args.iter().map(|s| s.as_str()).collect();
+        terminal.spawn_async(vte4::PtyFlags::DEFAULT, None, &ssh_args_refs, &env_refs, glib::SpawnFlags::SEARCH_PATH, || {}, -1, None::<&gio::Cancellable>, |_| {});
+    }
+
+    fn spawn_explorer(notebook: &gtk4::Notebook, win: &gtk4::ApplicationWindow, host: SshHost) {
+        let h_alias = host.alias.clone();
+        let nb = notebook.clone();
+        let window = win.clone();
+        glib::MainContext::default().spawn_local(async move {
+            let password = Self::get_keyring_password(&h_alias).await;
+            let explorer = FileExplorer::new(host, password);
+            let count = Self::count_pages_with_prefix(&nb, &format!("explorer:{}", h_alias));
+            explorer.container.set_widget_name(&format!("explorer:{}:{}", h_alias, count));
+
+            let display_name = if count > 0 { format!("📁 {} ({})", h_alias, count) } else { format!("📁 {}", h_alias) };
+            
+            let nb_inner = nb.clone();
+            let ex_inner = explorer.container.clone();
+            let win_inner = window.clone();
+            let tab_box = Self::create_tab_label(&display_name, move || {
+                let nb_confirm = nb_inner.clone();
+                let ex_confirm = ex_inner.clone();
+                let on_confirm = move || {
+                    if let Some(i) = nb_confirm.page_num(&ex_confirm) { nb_confirm.remove_page(Some(i)); }
+                };
+                if crate::config_observer::load_app_config().confirm_tab_close {
+                    show_close_confirmation(win_inner.upcast_ref(), "Close Explorer?", "Are you sure you want to close this explorer tab?", on_confirm);
+                } else { on_confirm(); }
+            });
+
+            let ins_pos = Self::get_insert_position(&nb);
+            nb.insert_page(&explorer.container, Some(&tab_box), Some(ins_pos));
+            nb.set_tab_reorderable(&explorer.container, true);
+            nb.set_current_page(Some(ins_pos));
+        });
+    }
+
+    fn spawn_monitor(notebook: &gtk4::Notebook, win: &gtk4::ApplicationWindow, host: SshHost) {
+        let h_alias = host.alias.clone();
+        let nb = notebook.clone();
+        let window = win.clone();
+        glib::MainContext::default().spawn_local(async move {
+            let password = Self::get_keyring_password(&h_alias).await;
+            let monitor = SystemMonitor::new(host, password);
+            let count = Self::count_pages_with_prefix(&nb, &format!("monitor:{}", h_alias));
+            monitor.container.set_widget_name(&format!("monitor:{}:{}", h_alias, count));
+
+            let display_name = if count > 0 { format!("📈 {} ({})", h_alias, count) } else { format!("📈 {}", h_alias) };
+            
+            let nb_inner = nb.clone();
+            let mo_inner = monitor.container.clone();
+            let win_inner = window.clone();
+            let tab_box = Self::create_tab_label(&display_name, move || {
+                let nb_confirm = nb_inner.clone();
+                let mo_confirm = mo_inner.clone();
+                let on_confirm = move || {
+                    if let Some(i) = nb_confirm.page_num(&mo_confirm) { nb_confirm.remove_page(Some(i)); }
+                };
+                if crate::config_observer::load_app_config().confirm_tab_close {
+                    show_close_confirmation(win_inner.upcast_ref(), "Close Monitor?", "Are you sure you want to close this monitoring tab?", on_confirm);
+                } else { on_confirm(); }
+            });
+
+            let ins_pos = Self::get_insert_position(&nb);
+            nb.insert_page(&monitor.container, Some(&tab_box), Some(ins_pos));
+            nb.set_tab_reorderable(&monitor.container, true);
+            nb.set_current_page(Some(ins_pos));
+        });
+    }
+
+    fn spawn_docker(notebook: &gtk4::Notebook, host: SshHost, password: Option<String>) {
+        let docker = DockerManager::new(host.clone(), password);
+        let label_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 4);
+        label_box.append(&crate::ui::get_docker_icon());
+        label_box.append(&gtk4::Label::new(Some(&format!("Docker: {}", host.alias))));
+        let close_btn = gtk4::Button::from_icon_name("window-close-symbolic");
+        close_btn.add_css_class("flat");
+        label_box.append(&close_btn);
         
-        let _ = crate::config_observer::save_app_config(&new_config);
-    };
+        let page_idx = notebook.append_page(&docker.container, Some(&label_box));
+        notebook.set_tab_reorderable(&docker.container, true);
+        notebook.set_current_page(Some(page_idx));
 
-    let save_fn = Rc::new(save_config);
-    
-    let s1 = save_fn.clone();
-    refresh_dropdown.connect_selected_notify(move |_| { s1(); });
-    
-    let s2 = save_fn.clone();
-    font_button.connect_font_set(move |_| { s2(); });
-    
-    let s3 = save_fn.clone();
-    scrollback_spinner.connect_value_changed(move |_| { s3(); });
-    
-    let s5 = save_fn.clone();
-    confirm_switch.connect_active_notify(move |_| { s5(); });
+        let nb_close = notebook.clone();
+        let child_close = docker.container.clone();
+        close_btn.connect_clicked(move |_| {
+            if let Some(i) = nb_close.page_num(&child_close) { nb_close.remove_page(Some(i)); }
+        });
+    }
 
-    scrolled.set_child(Some(&content));
-    container.append(&scrolled);
-    container
+    fn delete_server(&self, host: SshHost) {
+        let _ = delete_host_from_config(&host.alias);
+        let alias_norm = host.alias.to_lowercase();
+        let this = self.clone();
+        glib::MainContext::default().spawn_local(async move {
+            if let Ok(keyring) = oo7::Keyring::new().await {
+                let mut attr = HashMap::new();
+                attr.insert("rustmius-server-alias", alias_norm.as_str());
+                if let Ok(items) = keyring.search_items(&attr).await {
+                    for item in items { let _ = item.delete().await; }
+                }
+            }
+            this.refresh();
+        });
+    }
+
+    fn edit_server(&self, host: SshHost) {
+        let old_alias = host.alias.clone();
+        let this = self.clone();
+        let existing_aliases: Vec<String> = load_hosts().into_iter().map(|h| h.alias.to_lowercase()).collect();
+        show_server_dialog(self.inner.window.upcast_ref(), Some(&host), existing_aliases, move |new_host, password| {
+            let _ = delete_host_from_config(&old_alias);
+            if let Ok(_) = add_host_to_config(&new_host) {
+                if !password.is_empty() {
+                    let host_alias = new_host.alias.clone();
+                    glib::MainContext::default().spawn_local(async move {
+                        if let Ok(keyring) = oo7::Keyring::new().await {
+                            let mut attr = HashMap::new();
+                            let alias_lower = host_alias.to_lowercase();
+                            attr.insert("rustmius-server-alias", alias_lower.as_str());
+                            let _ = keyring.create_item(&format!("Rustmius: SSH Password for {}", host_alias), &attr, password.as_bytes(), true).await;
+                        }
+                    });
+                }
+                this.refresh();
+            }
+        });
+    }
+
+    // Helper methods
+    async fn get_keyring_password(alias: &str) -> Option<String> {
+        if let Ok(keyring) = oo7::Keyring::new().await {
+            let mut attr = HashMap::new();
+            let alias_lower = alias.to_lowercase();
+            attr.insert("rustmius-server-alias", alias_lower.as_str());
+            if let Ok(items) = keyring.search_items(&attr).await
+                && let Some(item) = items.first()
+                && let Ok(pass) = item.secret().await {
+                return std::str::from_utf8(pass.as_ref()).map(String::from).ok();
+            }
+        }
+        None
+    }
+
+    fn count_pages_with_prefix(notebook: &gtk4::Notebook, prefix: &str) -> u32 {
+        let mut count = 0;
+        for i in 0..notebook.n_pages() {
+            if let Some(p) = notebook.nth_page(Some(i))
+                && p.widget_name().starts_with(prefix) { count += 1; }
+        }
+        count
+    }
+
+    fn get_insert_position(notebook: &gtk4::Notebook) -> u32 {
+        for i in 0..notebook.n_pages() {
+            if let Some(c) = notebook.nth_page(Some(i))
+                && c.widget_name() == "plus_tab_dummy" { return i; }
+        }
+        notebook.n_pages()
+    }
+
+    fn create_tab_label(text: &str, on_close: impl Fn() + 'static) -> gtk4::Box {
+        let tab_box = gtk4::Box::new(gtk4::Orientation::Horizontal, 6);
+        tab_box.append(&gtk4::Label::new(Some(text)));
+        let close_btn = gtk4::Button::from_icon_name("window-close-symbolic");
+        close_btn.add_css_class("flat");
+        close_btn.connect_clicked(move |_| on_close());
+        tab_box.append(&close_btn);
+        tab_box
+    }
 }
 
-fn show_close_confirmation(parent: &gtk4::ApplicationWindow, title: &str, message: &str, on_confirm: impl FnOnce() + 'static) {
+pub fn build_ui(app: &gtk4::Application) {
+    AppWindow::new(app);
+}
+
+fn show_close_confirmation(parent: &gtk4::Window, title: &str, message: &str, on_confirm: impl FnOnce() + 'static) {
     let dialog = gtk4::MessageDialog::builder()
         .transient_for(parent)
         .modal(true)
@@ -705,13 +493,10 @@ fn show_close_confirmation(parent: &gtk4::ApplicationWindow, title: &str, messag
         .text(title)
         .secondary_text(message)
         .build();
-    
-    let on_confirm = std::cell::RefCell::new(Some(on_confirm));
+    let on_confirm = RefCell::new(Some(on_confirm));
     dialog.connect_response(move |d, response| {
         if response == gtk4::ResponseType::Ok {
-            if let Some(callback) = on_confirm.borrow_mut().take() {
-                callback();
-            }
+            if let Some(callback) = on_confirm.borrow_mut().take() { callback(); }
         }
         d.close();
     });


### PR DESCRIPTION
This pull request introduces three new UI components—`Sidebar`, `Header`, and `Settings`—and integrates them into the application's UI module. These components are designed using GTK4 and encapsulate distinct parts of the interface, making the codebase more modular and maintainable.

**New UI Components:**

* Added a `Sidebar` component with navigation buttons for servers, keys, and settings, using symbolic icons and a vertical layout (`src/ui/components/sidebar.rs`).
* Added a `Header` component with a header bar and an "add" button, styled for prominence (`src/ui/components/header.rs`).
* Added a `Settings` component, providing a detailed settings UI for terminal font, scrollback lines, monitor refresh rate, and tab close confirmation, with live config saving (`src/ui/components/settings.rs`).

**Module Integration:**

* Exposed the new UI components by adding them to the `components` module and updating the main UI module to include `components` (`src/ui/components/mod.rs`, `src/ui/mod.rs`). [[1]](diffhunk://#diff-39fee2e00393629bdf343fd2cdb452c8d6dfd99fb5bd40976d0c4f59c556e532R1-R3) [[2]](diffhunk://#diff-1b16d2199af085af653f62d275312de8a650ede0fdb65a9d22c1b6d71951d458R4)…Window struct