### PR TITLE
refactor: pass SshHost and password by reference to engine functions

### DIFF
--- a/src/sftp_engine.rs
+++ b/src/sftp_engine.rs
@@ -24,7 +24,7 @@ fn get_session_pool() -> &'static Mutex<HashMap<String, Arc<HostLock>>> {
     POOL.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-async fn get_or_connect_sftp(host: &SshHost, password: &Option<String>) -> anyhow::Result<Arc<ActiveSession>> {
+async fn get_or_connect_sftp(host: &SshHost, password: Option<&str>) -> anyhow::Result<Arc<ActiveSession>> {
     let host_key = format!("{}@{}", host.user.as_deref().unwrap_or("root"), host.hostname);
     
     let host_lock = {
@@ -40,7 +40,7 @@ async fn get_or_connect_sftp(host: &SshHost, password: &Option<String>) -> anyho
         }
     }
 
-    let sess = crate::ssh_engine::establish_ssh_session(host, password.clone()).await?;
+    let sess = crate::ssh_engine::establish_ssh_session(host, password).await?;
 
     let sftp_sess = sess.clone();
     let sftp = tokio::task::spawn_blocking(move || {
@@ -53,10 +53,11 @@ async fn get_or_connect_sftp(host: &SshHost, password: &Option<String>) -> anyho
     Ok(active)
 }
 
-pub async fn list_files(host: SshHost, password: Option<String>, path: String) -> anyhow::Result<Vec<RemoteFile>> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn list_files(host: &SshHost, password: Option<&str>, path: &str) -> anyhow::Result<Vec<RemoteFile>> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let path_owned = path.to_string();
     tokio::task::spawn_blocking(move || {
-        let dir = active.sftp.readdir(Path::new(&path))?;
+        let dir = active.sftp.readdir(Path::new(&path_owned))?;
         let mut files = Vec::new();
         for (path, stat) in dir {
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
@@ -79,10 +80,11 @@ pub async fn list_files(host: SshHost, password: Option<String>, path: String) -
     }).await?
 }
 
-pub async fn delete_file(host: SshHost, password: Option<String>, path: String, is_dir: bool) -> anyhow::Result<()> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn delete_file(host: &SshHost, password: Option<&str>, path: &str, is_dir: bool) -> anyhow::Result<()> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let path_owned = path.to_string();
     tokio::task::spawn_blocking(move || {
-        let p = Path::new(&path);
+        let p = Path::new(&path_owned);
         if is_dir {
             active.sftp.rmdir(p)?;
         } else {
@@ -92,35 +94,41 @@ pub async fn delete_file(host: SshHost, password: Option<String>, path: String, 
     }).await?
 }
 
-pub async fn create_dir(host: SshHost, password: Option<String>, path: String) -> anyhow::Result<()> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn create_dir(host: &SshHost, password: Option<&str>, path: &str) -> anyhow::Result<()> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let path_owned = path.to_string();
     tokio::task::spawn_blocking(move || {
-        active.sftp.mkdir(Path::new(&path), 0o755)?;
+        active.sftp.mkdir(Path::new(&path_owned), 0o755)?;
         Ok(())
     }).await?
 }
 
-pub async fn create_file(host: SshHost, password: Option<String>, path: String) -> anyhow::Result<()> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn create_file(host: &SshHost, password: Option<&str>, path: &str) -> anyhow::Result<()> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let path_owned = path.to_string();
     tokio::task::spawn_blocking(move || {
-        active.sftp.create(Path::new(&path))?;
+        active.sftp.create(Path::new(&path_owned))?;
         Ok(())
     }).await?
 }
 
-pub async fn rename_file(host: SshHost, password: Option<String>, old_path: String, new_path: String) -> anyhow::Result<()> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn rename_file(host: &SshHost, password: Option<&str>, old_path: &str, new_path: &str) -> anyhow::Result<()> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let old_owned = old_path.to_string();
+    let new_owned = new_path.to_string();
     tokio::task::spawn_blocking(move || {
-        active.sftp.rename(Path::new(&old_path), Path::new(&new_path), None)?;
+        active.sftp.rename(Path::new(&old_owned), Path::new(&new_owned), None)?;
         Ok(())
     }).await?
 }
 
-pub async fn upload_file(host: SshHost, password: Option<String>, local_path: String, remote_path: String) -> anyhow::Result<()> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn upload_file(host: &SshHost, password: Option<&str>, local_path: &str, remote_path: &str) -> anyhow::Result<()> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let local_owned = local_path.to_string();
+    let remote_owned = remote_path.to_string();
     tokio::task::spawn_blocking(move || {
-        let mut local_file = std::fs::File::open(local_path)?;
-        let mut remote_file = active.sftp.create(Path::new(&remote_path))?;
+        let mut local_file = std::fs::File::open(local_owned)?;
+        let mut remote_file = active.sftp.create(Path::new(&remote_owned))?;
         let mut buffer = [0; 16384];
         while let Ok(n) = local_file.read(&mut buffer) {
             if n == 0 { break; }
@@ -131,11 +139,13 @@ pub async fn upload_file(host: SshHost, password: Option<String>, local_path: St
 }
 
 #[allow(dead_code)]
-pub async fn download_file(host: SshHost, password: Option<String>, remote_path: String, local_path: String) -> anyhow::Result<()> {
-    let active = get_or_connect_sftp(&host, &password).await?;
+pub async fn download_file(host: &SshHost, password: Option<&str>, remote_path: &str, local_path: &str) -> anyhow::Result<()> {
+    let active = get_or_connect_sftp(host, password).await?;
+    let remote_owned = remote_path.to_string();
+    let local_owned = local_path.to_string();
     tokio::task::spawn_blocking(move || {
-        let mut remote_file = active.sftp.open(Path::new(&remote_path))?;
-        let mut local_file = std::fs::File::create(local_path)?;
+        let mut remote_file = active.sftp.open(Path::new(&remote_owned))?;
+        let mut local_file = std::fs::File::create(local_owned)?;
 
         let mut buffer = [0; 16384];
         while let Ok(n) = remote_file.read(&mut buffer) {
@@ -146,11 +156,11 @@ pub async fn download_file(host: SshHost, password: Option<String>, remote_path:
     }).await?
 }
 
-pub fn download_file_sync(host: SshHost, password: Option<String>, remote_path: String, local_path: String) -> anyhow::Result<()> {
+pub fn download_file_sync(host: &SshHost, password: Option<&str>, remote_path: &str, local_path: &str) -> anyhow::Result<()> {
     let runtime = tokio::runtime::Handle::current();
-    let active = runtime.block_on(get_or_connect_sftp(&host, &password))?;
+    let active = runtime.block_on(get_or_connect_sftp(host, password))?;
     
-    let mut remote_file = active.sftp.open(Path::new(&remote_path))?;
+    let mut remote_file = active.sftp.open(Path::new(remote_path))?;
     let mut local_file = std::fs::File::create(local_path)?;
 
     let mut buffer = [0; 16384];

--- a/src/ssh_engine.rs
+++ b/src/ssh_engine.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use crate::config_observer::{SshHost, expand_tilde};
 use tokio::net::{TcpStream, lookup_host};
 
-pub async fn establish_ssh_session(host: &SshHost, password: Option<String>) -> anyhow::Result<Session> {
+pub async fn establish_ssh_session(host: &SshHost, password: Option<&str>) -> anyhow::Result<Session> {
     let port = host.port.unwrap_or(22);
     let addr_str = format!("{}:{}", host.hostname, port);
     
@@ -27,6 +27,7 @@ pub async fn establish_ssh_session(host: &SshHost, password: Option<String>) -> 
     std_tcp.set_nonblocking(false)?;
 
     let host_cloned = host.clone();
+    let password_cloned = password.map(|s| s.to_string());
     tokio::task::spawn_blocking(move || {
         let mut sess = Session::new()
             .context("Failed to create SSH session")?;
@@ -48,8 +49,8 @@ pub async fn establish_ssh_session(host: &SshHost, password: Option<String>) -> 
             authenticated = true;
         }
 
-        if !authenticated && let Some(pass) = password {
-            if sess.userauth_password(user, &pass).is_ok() {
+        if !authenticated && let Some(ref pass) = password_cloned {
+            if sess.userauth_password(user, pass).is_ok() {
                 authenticated = true;
             }
         }
@@ -62,17 +63,18 @@ pub async fn establish_ssh_session(host: &SshHost, password: Option<String>) -> 
     }).await?
 }
 
-pub async fn deploy_pubkey(host: SshHost, password: Option<String>, pubkey_content: String) -> anyhow::Result<()> {
-    let sess = establish_ssh_session(&host, password).await?;
+pub async fn deploy_pubkey(host: &SshHost, password: Option<&str>, pubkey_content: &str) -> anyhow::Result<()> {
+    let sess = establish_ssh_session(host, password).await?;
+    let pubkey_owned = pubkey_content.to_string();
     
     tokio::task::spawn_blocking(move || {
         let mut channel = sess.channel_session()?;
         channel.exec("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")?;
 
-        if pubkey_content.ends_with('\n') {
-            channel.write_all(pubkey_content.as_bytes())?;
+        if pubkey_owned.ends_with('\n') {
+            channel.write_all(pubkey_owned.as_bytes())?;
         } else {
-            let mut content = pubkey_content.to_owned();
+            let mut content = pubkey_owned;
             content.push('\n');
             channel.write_all(content.as_bytes())?;
         }
@@ -84,12 +86,13 @@ pub async fn deploy_pubkey(host: SshHost, password: Option<String>, pubkey_conte
     }).await?
 }
 
-pub async fn run_remote_command(host: SshHost, password: Option<String>, command: String) -> anyhow::Result<String> {
-    let sess = establish_ssh_session(&host, password).await?;
+pub async fn run_remote_command(host: &SshHost, password: Option<&str>, command: &str) -> anyhow::Result<String> {
+    let sess = establish_ssh_session(host, password).await?;
+    let cmd_owned = command.to_string();
 
     tokio::task::spawn_blocking(move || {
         let mut channel = sess.channel_session()?;
-        channel.exec(&command)?;
+        channel.exec(&cmd_owned)?;
         let mut output = String::new();
         channel.read_to_string(&mut output)?;
         channel.wait_close()?;

--- a/src/ui/docker.rs
+++ b/src/ui/docker.rs
@@ -258,7 +258,7 @@ impl DockerManager {
                 let h_for_fetch = h.clone();
                 let p_for_fetch = p.clone();
                 let c_for_fetch = c.clone();
-                let result = run_remote_command(h_for_fetch, p_for_fetch, c_for_fetch).await;
+                let result = run_remote_command(&h_for_fetch, p_for_fetch.as_deref(), &c_for_fetch).await;
 
                 if let Ok(output) = result {
                     while let Some(child) = lb.first_child() { lb.remove(&child); }
@@ -320,7 +320,7 @@ impl DockerManager {
                                 let c_str = cmd_str.clone();
                                 glib::MainContext::default().spawn_local(async move {
                                     let cmd = format!("DOCKER_BIN=$(if [ -w /var/run/docker.sock ]; then echo 'docker'; else echo 'sudo -n docker'; fi); $DOCKER_BIN {} {}", c_str, n_c);
-                                    let _ = run_remote_command(h_c, p_c, cmd).await;
+                                    let _ = run_remote_command(&h_c, p_c.as_deref(), &cmd).await;
                                     rb_c.emit_clicked();
                                 });
                             });
@@ -345,8 +345,7 @@ impl DockerManager {
                             glib::MainContext::default().spawn_local(async move {
                                 let sub_cmd = if is_c_del { "rm -f" } else { "rmi" };
                                 let cmd = format!("DOCKER_BIN=$(if [ -w /var/run/docker.sock ]; then echo 'docker'; else echo 'sudo -n docker'; fi); $DOCKER_BIN {} {}", sub_cmd, n_c);
-                                let _ = run_remote_command(h_c, p_c, cmd).await;
-                                rb_c.emit_clicked();
+                                let _ = run_remote_command(&h_c, p_c.as_deref(), &cmd).await;                                rb_c.emit_clicked();
                             });
                         });
 
@@ -406,7 +405,7 @@ impl DockerManager {
                          echo $OUT; \
                        fi";
             
-            let result = run_remote_command(host, password, cmd.to_string()).await;
+            let result = run_remote_command(&host, password.as_deref(), &cmd).await;
 
             match result {
                 Ok(output) => {

--- a/src/ui/file_explorer.rs
+++ b/src/ui/file_explorer.rs
@@ -163,7 +163,7 @@ impl FileExplorer {
                 let local_str = local_path.to_string_lossy().to_string();
                 let h_task = h.clone();
                 glib::MainContext::default().spawn_local(async move {
-                    match upload_file(h_task.host.clone(), h_task.password.clone(), local_str, remote_dest).await {
+                    match upload_file(&h_task.host, h_task.password.as_deref(), &local_str, &remote_dest).await {
                         Ok(_) => {
                             h_task.status_label.set_text("Upload complete.");
                             h_task.refresh();
@@ -229,7 +229,7 @@ impl FileExplorer {
             show_input_dialog(parent_window.as_ref(), "New Folder", "Name:", "", move |n| {
                 let sli = sl.clone(); let p = format!("{}{}", cur, n);
                 glib::MainContext::default().spawn_local(async move {
-                    if let Ok(_) = create_dir(sli.host.clone(), sli.password.clone(), p).await { sli.refresh(); }
+                    if let Ok(_) = create_dir(&sli.host, sli.password.as_deref(), &p).await { sli.refresh(); }
                 });
             });
         });
@@ -282,7 +282,7 @@ impl ExplorerHandle {
         lb.append(&loading);
 
         glib::MainContext::default().spawn_local(async move {
-            match list_files(h, pw, p).await {
+            match list_files(&h, pw.as_deref(), &p).await {
                 Ok(files) => {
                     while let Some(row) = lb.row_at_index(0) {
                         unparent_children(&row);
@@ -364,15 +364,14 @@ impl ExplorerHandle {
                     );
                 src.set_icon(Some(&paintable), 16, 16);
 
-                let host = h.host.clone();
-                let password = h.password.clone();
                 let rp = remote_path.clone();
                 let lp_part = local_tmp_part.clone();
                 let lp_final = local_tmp.clone();
 
+                let h_cloned = h.clone();
                 h.status_label.set_text(&format!("Preparing {}...", f.name));
                 std::thread::spawn(move || {
-                    if let Ok(_) = crate::sftp_engine::download_file_sync(host, password, rp, lp_part.clone()) {
+                    if let Ok(_) = crate::sftp_engine::download_file_sync(&h_cloned.host, h_cloned.password.as_deref(), &rp, &lp_part) {
                         let _ = std::fs::rename(lp_part, lp_final);
                     }
                 });
@@ -428,11 +427,9 @@ impl ExplorerHandle {
                                     let lp = path.to_string_lossy().to_string();
                                     hii.status_label.set_text(&format!("Downloading {}...", fi.name));
                                     let hiii = hii.clone();
-                                    let host = hiii.host.clone();
-                                    let pass = hiii.password.clone();
                                     glib::MainContext::default().spawn_local(async move {
                                         let rp = rp.clone();
-                                        match crate::sftp_engine::download_file(host, pass, rp, lp).await {
+                                        match crate::sftp_engine::download_file(&hiii.host, hiii.password.as_deref(), &rp, &lp).await {
                                             Ok(_) => hiii.status_label.set_text("Download complete."),
                                             Err(e) => hiii.status_label.set_text(&format!("Download error: {}", e)),
                                         }
@@ -453,7 +450,7 @@ impl ExplorerHandle {
                 show_confirm_dialog(parent_window.as_ref(), "Confirm Delete", &format!("Delete '{}'?", fi.name), move || {
                     let hii = hi.clone(); let p = path.clone(); let isd = fi.is_dir;
                     glib::MainContext::default().spawn_local(async move {
-                        match delete_file(hii.host.clone(), hii.password.clone(), p, isd).await {
+                        match delete_file(&hii.host, hii.password.as_deref(), &p, isd).await {
                             Ok(_) => hii.refresh(),
                             Err(e) => hii.status_label.set_text(&format!("Delete error: {}", e)),
                         }
@@ -475,7 +472,7 @@ impl ExplorerHandle {
                     let old_p = format!("{}{}", cur, old_name_cloned);
                     let new_p = format!("{}{}", cur, new_n);
                     glib::MainContext::default().spawn_local(async move {
-                        match rename_file(hii.host.clone(), hii.password.clone(), old_p, new_p).await {
+                        match rename_file(&hii.host, hii.password.as_deref(), &old_p, &new_p).await {
                             Ok(_) => hii.refresh(),
                             Err(e) => hii.status_label.set_text(&format!("Rename error: {}", e)),
                         }
@@ -494,7 +491,7 @@ impl ExplorerHandle {
                     show_input_dialog(parent_window.as_ref(), "New File", "Name:", "", move |n| {
                         let hii = hi.clone(); let p = format!("{}{}", pb, n);
                         glib::MainContext::default().spawn_local(async move {
-                            match create_file(hii.host.clone(), hii.password.clone(), p).await {
+                            match create_file(&hii.host, hii.password.as_deref(), &p).await {
                                 Ok(_) => hii.refresh(),
                                 Err(e) => hii.status_label.set_text(&format!("Error: {}", e)),
                             }
@@ -512,7 +509,7 @@ impl ExplorerHandle {
                     show_input_dialog(parent_window.as_ref(), "New Folder", "Name:", "", move |n| {
                         let hii = hi.clone(); let p = format!("{}{}", pb, n);
                         glib::MainContext::default().spawn_local(async move {
-                            match create_dir(hii.host.clone(), hii.password.clone(), p).await {
+                            match create_dir(&hii.host, hii.password.as_deref(), &p).await {
                                 Ok(_) => hii.refresh(),
                                 Err(e) => hii.status_label.set_text(&format!("Error: {}", e)),
                             }

--- a/src/ui/monitor.rs
+++ b/src/ui/monitor.rs
@@ -214,10 +214,7 @@ impl SystemMonitor {
                            echo \"---DISK_ALL---\"; df -h / --output=pcent,used,size | awk 'NR==2 {print $1, $2, $3}'; \
                            echo \"---CPU_P---\"; top -bn2 -d 0.2 | grep \"%Cpu\" | tail -1 | awk -F',' '{for(i=1;i<=NF;i++) if($i ~ /id/) print $i}' | awk '{print 100-$1}'";
 
-                let h = h_clone.clone();
-                let p = p_clone.clone();
-                
-                let result = run_remote_command(h, p, cmd.to_string()).await;
+                let result = run_remote_command(&h_clone, p_clone.as_deref(), cmd).await;
 
                 if let Ok(output) = result {
                     if let Ok(mut st) = s_clone.try_borrow_mut() {

--- a/src/ui/ssh_keys.rs
+++ b/src/ui/ssh_keys.rs
@@ -323,9 +323,7 @@ fn show_deploy_dialog(parent: &gtk4::ApplicationWindow, key: &SshKeyPair) {
                                 }
                     }
 
-                    let h_c = host.clone();
-                    let pk_c = pubkey.clone();
-                    let result = crate::ssh_engine::deploy_pubkey(h_c, final_password, pk_c).await;
+                    let result = crate::ssh_engine::deploy_pubkey(&host, final_password.as_deref(), &pubkey).await;
 
                     match result {
                         Ok(_) => {


### PR DESCRIPTION
This pull request refactors the SSH and SFTP interface functions to consistently use references for host, password, and path parameters, instead of passing owned values. This change improves efficiency by avoiding unnecessary cloning and allocations, and ensures more consistent API usage throughout the codebase. All call sites in the UI and logic layers are updated to match the new function signatures.

**API Refactoring and Consistency:**

* All SFTP and SSH-related functions in `src/sftp_engine.rs` and `src/ssh_engine.rs` now take parameters as references (e.g., `&SshHost`, `Option<&str>`, `&str`) instead of owned values, reducing unnecessary cloning and allocations. [[1]](diffhunk://#diff-7636ca087660b291e72a06f65c3d56805688feeae5bc8e06fc77e0ef405de987L27-R27) [[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL8-R8)
* Updated internal logic to convert referenced strings to owned values only when needed for blocking tasks, ensuring minimal allocations. [[1]](diffhunk://#diff-7636ca087660b291e72a06f65c3d56805688feeae5bc8e06fc77e0ef405de987L56-R60) [[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL65-R77)

**UI Integration Updates:**

* All calls to SFTP and SSH functions in `src/ui/file_explorer.rs` and `src/ui/docker.rs` are updated to pass references and use `.as_deref()` for optional passwords, ensuring compatibility with the new function signatures. [[1]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L166-R166) [[2]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L261-R261) [[3]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L232-R232) [[4]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L285-R285) [[5]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L367-R374) [[6]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L431-R432) [[7]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L456-R453) [[8]](diffhunk://#diff-64f44d880a4da3280dc711df1b7acebe9075724ca7c8d13fcb44e1ce5964b5e7L478-R475) [[9]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L323-R323) [[10]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L348-R348) [[11]](diffhunk://#diff-fbf86c283435b255d1aa56187b473c07459bb4b93362c4bb054c88b9e1731350L409-R408)

**Authentication Handling:**

* Passwords are now cloned only when necessary for authentication, improving clarity and reducing redundant allocations in `establish_ssh_session`. [[1]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eR30) [[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL51-R53)

Overall, these changes make the codebase more efficient and idiomatic by leveraging references and reducing unnecessary data copying, while also simplifying the integration points in the UI code.