### PR TITLE
refactor: optimize SFTP file transfers using std::io::copy

### DIFF
--- a/src/sftp_engine.rs
+++ b/src/sftp_engine.rs
@@ -1,6 +1,5 @@
 use ssh2::Session;
 use std::path::Path;
-use std::io::{Read, Write};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::collections::HashMap;
 use crate::config_observer::SshHost;
@@ -129,11 +128,7 @@ pub async fn upload_file(host: &SshHost, password: Option<&str>, local_path: &st
     tokio::task::spawn_blocking(move || {
         let mut local_file = std::fs::File::open(local_owned)?;
         let mut remote_file = active.sftp.create(Path::new(&remote_owned))?;
-        let mut buffer = [0; 16384];
-        while let Ok(n) = local_file.read(&mut buffer) {
-            if n == 0 { break; }
-            remote_file.write_all(&buffer[..n])?;
-        }
+        std::io::copy(&mut local_file, &mut remote_file)?;
         Ok(())
     }).await?
 }
@@ -146,12 +141,7 @@ pub async fn download_file(host: &SshHost, password: Option<&str>, remote_path: 
     tokio::task::spawn_blocking(move || {
         let mut remote_file = active.sftp.open(Path::new(&remote_owned))?;
         let mut local_file = std::fs::File::create(local_owned)?;
-
-        let mut buffer = [0; 16384];
-        while let Ok(n) = remote_file.read(&mut buffer) {
-            if n == 0 { break; }
-            local_file.write_all(&buffer[..n])?;
-        }
+        std::io::copy(&mut remote_file, &mut local_file)?;
         Ok(())
     }).await?
 }
@@ -162,11 +152,6 @@ pub fn download_file_sync(host: &SshHost, password: Option<&str>, remote_path: &
     
     let mut remote_file = active.sftp.open(Path::new(remote_path))?;
     let mut local_file = std::fs::File::create(local_path)?;
-
-    let mut buffer = [0; 16384];
-    while let Ok(n) = remote_file.read(&mut buffer) {
-        if n == 0 { break; }
-        local_file.write_all(&buffer[..n])?;
-    }
+    std::io::copy(&mut remote_file, &mut local_file)?;
     Ok(())
 }

--- a/src/sftp_engine.rs
+++ b/src/sftp_engine.rs
@@ -141,16 +141,15 @@ pub async fn download_file(host: &SshHost, password: Option<&str>, remote_path: 
     tokio::task::spawn_blocking(move || {
         let mut remote_file = active.sftp.open(Path::new(&remote_owned))?;
         let mut local_file = std::fs::File::create(local_owned)?;
-        std::io::copy(&mut remote_file, &mut local_file)?;
+        std::io::copy(&mut local_file, &mut remote_file)?;
         Ok(())
     }).await?
 }
 
-pub fn download_file_sync(host: &SshHost, password: Option<&str>, remote_path: &str, local_path: &str) -> anyhow::Result<()> {
-    let runtime = tokio::runtime::Handle::current();
-    let active = runtime.block_on(get_or_connect_sftp(host, password))?;
+pub fn download_file_sync(rt: tokio::runtime::Handle, host: SshHost, password: Option<String>, remote_path: String, local_path: String) -> anyhow::Result<()> {
+    let active = rt.block_on(get_or_connect_sftp(&host, password.as_deref()))?;
     
-    let mut remote_file = active.sftp.open(Path::new(remote_path))?;
+    let mut remote_file = active.sftp.open(Path::new(&remote_path))?;
     let mut local_file = std::fs::File::create(local_path)?;
     std::io::copy(&mut remote_file, &mut local_file)?;
     Ok(())

--- a/src/ui/file_explorer.rs
+++ b/src/ui/file_explorer.rs
@@ -364,14 +364,16 @@ impl ExplorerHandle {
                     );
                 src.set_icon(Some(&paintable), 16, 16);
 
+                let host = h.host.clone();
+                let password = h.password.clone();
                 let rp = remote_path.clone();
                 let lp_part = local_tmp_part.clone();
                 let lp_final = local_tmp.clone();
+                let rt = tokio::runtime::Handle::current();
 
-                let h_cloned = h.clone();
                 h.status_label.set_text(&format!("Preparing {}...", f.name));
                 std::thread::spawn(move || {
-                    if let Ok(_) = crate::sftp_engine::download_file_sync(&h_cloned.host, h_cloned.password.as_deref(), &rp, &lp_part) {
+                    if let Ok(_) = crate::sftp_engine::download_file_sync(rt, host, password, rp, lp_part.clone()) {
                         let _ = std::fs::rename(lp_part, lp_final);
                     }
                 });


### PR DESCRIPTION
This pull request refactors the SFTP file transfer logic to simplify the code and improve efficiency by using `std::io::copy` for file transfers instead of manual buffer management. It also updates the synchronous download function to take ownership of its parameters and a Tokio runtime handle, aligning its API with async best practices. The file explorer UI is updated to use the new function signature.

**SFTP file transfer improvements:**

* Replaced manual read/write buffer loops with `std::io::copy` in both `upload_file`, `download_file`, and `download_file_sync` for more concise and efficient file transfer code. [[1]](diffhunk://#diff-7636ca087660b291e72a06f65c3d56805688feeae5bc8e06fc77e0ef405de987L132-R131) [[2]](diffhunk://#diff-7636ca087660b291e72a06f65c3d56805688feeae5bc8e06fc77e0ef405de987L149-R154)
* Updated `download_file_sync` to accept a Tokio runtime handle and take ownership of its parameters, improving its API and thread safety.

**UI integration updates:**

* Modified the file explorer to pass the current Tokio runtime handle and owned parameters to the new `download_file_sync` signature, ensuring compatibility with the refactored SFTP logic.