### PR TITLE
refactor: centralize system paths and SSH key discovery 

### DIFF
--- a/src/config_observer.rs
+++ b/src/config_observer.rs
@@ -14,6 +14,46 @@ pub fn expand_tilde(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
+pub fn get_ssh_dir() -> Option<PathBuf> {
+    UserDirs::new().map(|dirs| dirs.home_dir().join(".ssh"))
+}
+
+pub const REMOTE_SSH_DIR: &str = "~/.ssh";
+pub const REMOTE_AUTHORIZED_KEYS: &str = "~/.ssh/authorized_keys";
+#[allow(dead_code)]
+pub const REMOTE_SSH_CONFIG: &str = "~/.ssh/config";
+
+#[derive(Debug, Clone)]
+pub struct SshKeyPair {
+    pub name: String,
+    pub pub_path: PathBuf,
+    pub priv_path: PathBuf,
+}
+
+pub fn load_ssh_keys() -> Vec<SshKeyPair> {
+    let mut keys = Vec::new();
+    if let Some(ssh_dir) = get_ssh_dir()
+        && let Ok(entries) = std::fs::read_dir(&ssh_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("pub") {
+                    let mut priv_path = path.clone();
+                    priv_path.set_extension("");
+                    if priv_path.exists() {
+                        let name = path.file_stem().unwrap_or_default().to_string_lossy().to_string();
+                        keys.push(SshKeyPair {
+                            name,
+                            pub_path: path,
+                            priv_path,
+                        });
+                    }
+                }
+            }
+        }
+    keys.sort_by(|a, b| a.name.cmp(&b.name));
+    keys
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AppConfig {
     pub monitor_refresh_rate: u32, // index: 0=1s, 1=3s, 2=5s, 3=10s
@@ -67,7 +107,7 @@ pub struct SshHost {
 }
 
 pub fn get_default_config_path() -> Option<std::path::PathBuf> {
-    UserDirs::new().map(|dirs| dirs.home_dir().join(".ssh").join("config"))
+    get_ssh_dir().map(|d| d.join("config"))
 }
 
 pub fn load_hosts() -> Vec<SshHost> {

--- a/src/ssh_engine.rs
+++ b/src/ssh_engine.rs
@@ -2,7 +2,7 @@ use ssh2::Session;
 use std::time::Duration;
 use std::io::{Read, Write};
 use anyhow::Context;
-use crate::config_observer::{SshHost, expand_tilde};
+use crate::config_observer::{SshHost, expand_tilde, REMOTE_SSH_DIR, REMOTE_AUTHORIZED_KEYS};
 use tokio::net::{TcpStream, lookup_host};
 
 pub async fn establish_ssh_session(host: &SshHost, password: Option<&str>) -> anyhow::Result<Session> {
@@ -69,7 +69,11 @@ pub async fn deploy_pubkey(host: &SshHost, password: Option<&str>, pubkey_conten
     
     tokio::task::spawn_blocking(move || {
         let mut channel = sess.channel_session()?;
-        channel.exec("mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")?;
+        let cmd = format!(
+            "mkdir -p {0} && chmod 700 {0} && cat >> {1} && chmod 600 {1}",
+            REMOTE_SSH_DIR, REMOTE_AUTHORIZED_KEYS
+        );
+        channel.exec(&cmd)?;
 
         if pubkey_owned.ends_with('\n') {
             channel.write_all(pubkey_owned.as_bytes())?;

--- a/src/ui/add_server_dialog.rs
+++ b/src/ui/add_server_dialog.rs
@@ -1,7 +1,6 @@
 #![allow(deprecated)]
 use gtk4::prelude::*;
-use crate::config_observer::SshHost;
-use crate::ui::ssh_keys::load_ssh_keys;
+use crate::config_observer::{SshHost, load_ssh_keys};
 
 pub fn show_server_dialog<F>(
     parent: &gtk4::Window,

--- a/src/ui/ssh_keys.rs
+++ b/src/ui/ssh_keys.rs
@@ -3,9 +3,7 @@ use gtk4::prelude::*;
 use gtk4::glib;
 use std::rc::Rc;
 use std::cell::RefCell;
-use directories::UserDirs;
-use std::path::PathBuf;
-use crate::config_observer::load_hosts;
+use crate::config_observer::{load_hosts, SshKeyPair, get_ssh_dir, load_ssh_keys, REMOTE_SSH_DIR};
 
 fn is_valid_key_name(name: &str) -> bool {
     if name.is_empty() || name.contains('\0') {
@@ -30,41 +28,6 @@ fn make_error_alert(parent: Option<&gtk4::Window>, title: &str, secondary: &str)
     };
     alert.connect_response(|a, _| a.close());
     alert
-}
-
-#[derive(Clone)]
-pub struct SshKeyPair {
-    pub name: String,
-    pub pub_path: PathBuf,
-    pub priv_path: PathBuf,
-}
-
-fn get_ssh_dir() -> Option<PathBuf> {
-    UserDirs::new().map(|dirs| dirs.home_dir().join(".ssh"))
-}
-
-pub fn load_ssh_keys() -> Vec<SshKeyPair> {
-    let mut keys = Vec::new();
-    if let Some(ssh_dir) = get_ssh_dir()
-        && let Ok(entries) = std::fs::read_dir(&ssh_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("pub") {
-                    let mut priv_path = path.clone();
-                    priv_path.set_extension("");
-                    if priv_path.exists() {
-                        let name = path.file_stem().unwrap_or_default().to_string_lossy().to_string();
-                        keys.push(SshKeyPair {
-                            name,
-                            pub_path: path,
-                            priv_path,
-                        });
-                    }
-                }
-            }
-        }
-    keys.sort_by(|a, b| a.name.cmp(&b.name));
-    keys
 }
 
 pub fn build_ssh_keys_ui(window: &gtk4::ApplicationWindow) -> gtk4::Box {
@@ -116,7 +79,7 @@ pub fn build_ssh_keys_ui(window: &gtk4::ApplicationWindow) -> gtk4::Box {
 
             let keys = load_ssh_keys();
             if keys.is_empty() {
-                let empty_lbl = gtk4::Label::new(Some("No SSH keys found in ~/.ssh/"));
+                let empty_lbl = gtk4::Label::new(Some(&format!("No SSH keys found in {}/", REMOTE_SSH_DIR)));
                 empty_lbl.set_margin_top(24);
                 empty_lbl.set_margin_bottom(24);
                 empty_lbl.add_css_class("dim-label");
@@ -421,7 +384,7 @@ fn show_generate_dialog(parent: &gtk4::ApplicationWindow, on_save: Rc<dyn Fn()>)
                     let alert = make_error_alert(
                         d.transient_for().as_ref().map(|w| w.upcast_ref()),
                         "Key Already Exists",
-                        &format!("A file named '{}' or its public key already exists in ~/.ssh/. Choose a different name.", name),
+                        &format!("A file named '{}' or its public key already exists in {}. Choose a different name.", name, REMOTE_SSH_DIR),
                     );
                     alert.present();
                     return;
@@ -540,7 +503,7 @@ fn show_import_dialog(parent: &gtk4::ApplicationWindow, on_save: Rc<dyn Fn()>) {
                     let alert = make_error_alert(
                         d.transient_for().as_ref().map(|w| w.upcast_ref()),
                         "Key Already Exists",
-                        &format!("A file named '{}' or its public key already exists in ~/.ssh/.", name),
+                        &format!("A file named '{}' or its public key already exists in {}.", name, REMOTE_SSH_DIR),
                     );
                     alert.present();
                     return;


### PR DESCRIPTION
This pull request refactors SSH key management and related constants to centralize logic, improve maintainability, and ensure consistent usage of SSH directory paths across the codebase. The main changes involve moving SSH key utilities and constants to `config_observer.rs`, updating references throughout the application, and enhancing user-facing messages for clarity.

**SSH Key Management Refactor:**

- Moved the `SshKeyPair` struct, `get_ssh_dir`, and `load_ssh_keys` functions from `ui/ssh_keys.rs` to `config_observer.rs`, consolidating SSH key logic in a single location. (`[[1]](diffhunk://#diff-62a48d93070189103c8bcddc6c959538d130cbd7c9349316fa20fc3575caa25cR17-R56)`, `[[2]](diffhunk://#diff-4750f20168a2936759b01f845a100a3b1044258228152af5e6519aa82463a7aaL35-L69)`)
- Updated imports and function calls in `ui/ssh_keys.rs` and `add_server_dialog.rs` to use the new centralized definitions from `config_observer.rs`. (`[[1]](diffhunk://#diff-4750f20168a2936759b01f845a100a3b1044258228152af5e6519aa82463a7aaL6-R6)`, `[[2]](diffhunk://#diff-d99b8afb47f078a6bc7632396dc533fdb025c64fc50ed134a142d46c4d9c6d09L3-R3)`)

**SSH Directory Constants and Usage:**

- Introduced constants `REMOTE_SSH_DIR`, `REMOTE_AUTHORIZED_KEYS`, and `REMOTE_SSH_CONFIG` in `config_observer.rs` for consistent referencing of SSH-related paths. (`[src/config_observer.rsR17-R56](diffhunk://#diff-62a48d93070189103c8bcddc6c959538d130cbd7c9349316fa20fc3575caa25cR17-R56)`)
- Updated the SSH public key deployment command in `ssh_engine.rs` to use these new constants, ensuring path correctness and maintainability. (`[[1]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL5-R5)`, `[[2]](diffhunk://#diff-f48442d6fe3dd48b17416029df81da8c6b5451d004bbd8cd074a377dfed85b5eL72-R76)`)

**UI Improvements:**

- Updated user-facing messages in the SSH keys UI to dynamically display the correct SSH directory path using the new constants, improving clarity for users. (`[[1]](diffhunk://#diff-4750f20168a2936759b01f845a100a3b1044258228152af5e6519aa82463a7aaL119-R82)`, `[[2]](diffhunk://#diff-4750f20168a2936759b01f845a100a3b1044258228152af5e6519aa82463a7aaL424-R387)`, `[[3]](diffhunk://#diff-4750f20168a2936759b01f845a100a3b1044258228152af5e6519aa82463a7aaL543-R506)`)

**Other Improvements:**

- Refactored `get_default_config_path` in `config_observer.rs` to use the new `get_ssh_dir` function for consistency. (`[src/config_observer.rsL70-R110](diffhunk://#diff-62a48d93070189103c8bcddc6c959538d130cbd7c9349316fa20fc3575caa25cL70-R110)`)

These changes collectively improve code organization, reduce duplication, and make the handling of SSH keys and paths more robust and user-friendly.