### PR TITLE
refactor: replace std::thread::spawn with tokio::task::spawn_blocking…

### DIFF
--- a/src/ui/file_explorer.rs
+++ b/src/ui/file_explorer.rs
@@ -372,8 +372,9 @@ impl ExplorerHandle {
                 let rt = tokio::runtime::Handle::current();
 
                 h.status_label.set_text(&format!("Preparing {}...", f.name));
-                std::thread::spawn(move || {
-                    if let Ok(_) = crate::sftp_engine::download_file_sync(rt, host, password, rp, lp_part.clone()) {
+                let rt_blocking = rt.clone();
+                rt.spawn_blocking(move || {
+                    if let Ok(_) = crate::sftp_engine::download_file_sync(rt_blocking, host, password, rp, lp_part.clone()) {
                         let _ = std::fs::rename(lp_part, lp_final);
                     }
                 });


### PR DESCRIPTION
This pull request refactors the way file downloads are executed in the `ExplorerHandle` implementation to improve async runtime usage and thread management.

**Async runtime and threading improvements:**

* Replaces the use of `std::thread::spawn` with `tokio::runtime::Handle::spawn_blocking` for running the blocking `download_file_sync` operation, ensuring better integration with the Tokio async runtime and avoiding potential runtime conflicts. (`src/ui/file_explorer.rs`)