### PR TITLE
refactor: finalize documentation, centralize keyring logic, and fix t…

### DIFF
--- a/src/config_observer.rs
+++ b/src/config_observer.rs
@@ -75,6 +75,23 @@ pub fn load_ssh_keys() -> anyhow::Result<Vec<SshKeyPair>> {
     Ok(keys)
 }
 
+/// Retrieves a password from the system keyring for a given server alias.
+pub async fn get_keyring_password(alias: &str) -> Option<String> {
+    if let Ok(keyring) = oo7::Keyring::new().await {
+        let mut attr = std::collections::HashMap::new();
+        let alias_lower = alias.to_lowercase();
+        attr.insert("rustmius-server-alias", alias_lower.as_str());
+        if let Ok(items) = keyring.search_items(&attr).await {
+            if let Some(item) = items.first() {
+                if let Ok(secret) = item.secret().await {
+                    return std::str::from_utf8(&secret).map(String::from).ok();
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Global application configuration settings.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AppConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,20 +20,10 @@ async fn main() {
     let _args: Vec<String> = std::env::args().collect();
     if let Ok(alias) = std::env::var("RUSTMIUS_ASKPASS_ALIAS") {
         debug!("AskPass triggered for alias: {}", alias);
-        if let Ok(keyring) = oo7::Keyring::new().await {
-            let mut attributes = std::collections::HashMap::new();
-            let normalized_alias = alias.to_lowercase();
-            attributes.insert("rustmius-server-alias", normalized_alias.as_str());
-            if let Ok(items) = keyring.search_items(&attributes).await {
-                debug!("Found {} items in keyring", items.len());
-                if let Some(item) = items.first()
-                    && let Ok(password) = item.secret().await
-                        && let Ok(pass_str) = std::str::from_utf8(password.as_ref()) {
-                            debug!("Password retrieved successfully, sending to SSH");
-                            print!("{}", pass_str);
-                            std::process::exit(0);
-                        }
-            }
+        if let Some(pass_str) = tokio::runtime::Handle::current().block_on(crate::config_observer::get_keyring_password(&alias)) {
+            debug!("Password retrieved successfully, sending to SSH");
+            print!("{}", pass_str);
+            std::process::exit(0);
         }
         error!("Failed to retrieve password from keyring for alias: {}", alias);
         std::process::exit(1);

--- a/src/ui/server_list.rs
+++ b/src/ui/server_list.rs
@@ -117,21 +117,7 @@ impl ServerList {
             let h = host_conn.clone();
             let oa = on_action_conn.clone();
             glib::MainContext::default().spawn_local(async move {
-                let mut password = None;
-                if let Ok(keyring) = oo7::Keyring::new().await {
-                    let mut attr = std::collections::HashMap::new();
-                    let alias_lower = h.alias.to_lowercase();
-                    attr.insert("rustmius-server-alias", alias_lower.as_str());
-                    if let Ok(items) = keyring.search_items(&attr).await {
-                        if let Some(item) = items.first() {
-                            if let Ok(secret) = item.secret().await {
-                                if let Ok(pass_str) = std::str::from_utf8(&secret) {
-                                    password = Some(pass_str.to_string());
-                                }
-                            }
-                        }
-                    }
-                }
+                let password = crate::config_observer::get_keyring_password(&h.alias).await;
                 oa(ServerAction::Connect(h, password));
             });
         });

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -135,7 +135,7 @@ impl AppWindow {
         });
         let existing_aliases: Vec<String> = existing_hosts.iter().map(|h| h.alias.to_lowercase()).collect();
         
-        show_server_dialog(self.inner.window.upcast_ref(), None, existing_aliases, move |new_host, password| {
+        show_server_dialog(self.inner.window.upcast_ref(), None, existing_aliases, move |new_host, password: String| {
             if let Ok(_) = add_host_to_config(&new_host) {
                 if !password.is_empty() {
                     let host_alias = new_host.alias.clone();
@@ -326,7 +326,7 @@ impl AppWindow {
         let nb = notebook.clone();
         let window = win.clone();
         glib::MainContext::default().spawn_local(async move {
-            let password = Self::get_keyring_password(&h_alias).await;
+            let password = crate::config_observer::get_keyring_password(&h_alias).await;
             let explorer = FileExplorer::new(host, password);
             let count = Self::count_pages_with_prefix(&nb, &format!("explorer:{}", h_alias));
             explorer.container.set_widget_name(&format!("explorer:{}:{}", h_alias, count));
@@ -359,7 +359,7 @@ impl AppWindow {
         let nb = notebook.clone();
         let window = win.clone();
         glib::MainContext::default().spawn_local(async move {
-            let password = Self::get_keyring_password(&h_alias).await;
+            let password = crate::config_observer::get_keyring_password(&h_alias).await;
             let monitor = SystemMonitor::new(host, password);
             let count = Self::count_pages_with_prefix(&nb, &format!("monitor:{}", h_alias));
             monitor.container.set_widget_name(&format!("monitor:{}:{}", h_alias, count));
@@ -447,21 +447,6 @@ impl AppWindow {
                 this.refresh();
             }
         });
-    }
-
-    // Helper methods
-    async fn get_keyring_password(alias: &str) -> Option<String> {
-        if let Ok(keyring) = oo7::Keyring::new().await {
-            let mut attr = HashMap::new();
-            let alias_lower = alias.to_lowercase();
-            attr.insert("rustmius-server-alias", alias_lower.as_str());
-            if let Ok(items) = keyring.search_items(&attr).await
-                && let Some(item) = items.first()
-                && let Ok(pass) = item.secret().await {
-                return std::str::from_utf8(pass.as_ref()).map(String::from).ok();
-            }
-        }
-        None
     }
 
     fn count_pages_with_prefix(notebook: &gtk4::Notebook, prefix: &str) -> u32 {


### PR DESCRIPTION
This pull request refactors how passwords are retrieved from the system keyring by centralizing the logic in a new asynchronous helper function, `get_keyring_password`, in `config_observer.rs`. The codebase now consistently uses this helper across the application, reducing duplication and improving maintainability.

**Key changes:**

**Keyring password retrieval refactor:**
* Added a new async helper function `get_keyring_password` to `config_observer.rs` for fetching passwords from the system keyring based on server alias.
* Replaced all previous direct keyring access logic in `main.rs`, `server_list.rs`, and `window.rs` with calls to the new `get_keyring_password` helper. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL23-L37) [[2]](diffhunk://#diff-3526ac424a577b4bc19f45cdf76ce670446972f9397e6c27bd30727560e59f72L120-R120) [[3]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L329-R329) [[4]](diffhunk://#diff-06e1e1bb917cbd5e91c5a3b25e6e042e22455fbed7007c14a6222700caafe577L362-R362)

**Code cleanup and simplification:**
* Removed the now-unnecessary private helper method `get_keyring_password` from `AppWindow` in `window.rs`, ensuring a single source of truth for keyring access.
* Minor signature update for the `show_server_dialog` closure to clarify the password type.