### PR TITLE
fix: resolve Tokio panic and silence logs in SSH askpass mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,23 +8,26 @@ use tracing::{debug, info, error};
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env()
-            .add_directive(tracing::Level::INFO.into())
-            .add_directive("rustmius=debug".parse().unwrap()))
-        .init();
+    let is_askpass = std::env::var("RUSTMIUS_ASKPASS_ALIAS").is_ok();
 
-    info!("Starting Rustmius v{}", env!("CARGO_PKG_VERSION"));
+    if !is_askpass {
+        tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into())
+                .add_directive("rustmius=debug".parse().unwrap()))
+            .init();
+        info!("Starting Rustmius v{}", env!("CARGO_PKG_VERSION"));
+    }
 
     let _args: Vec<String> = std::env::args().collect();
     if let Ok(alias) = std::env::var("RUSTMIUS_ASKPASS_ALIAS") {
-        debug!("AskPass triggered for alias: {}", alias);
-        if let Some(pass_str) = tokio::runtime::Handle::current().block_on(crate::config_observer::get_keyring_password(&alias)) {
-            debug!("Password retrieved successfully, sending to SSH");
-            print!("{}", pass_str);
+        if let Some(pass_str) = crate::config_observer::get_keyring_password(&alias).await {
+            use std::io::Write;
+            let _ = std::io::stdout().write_all(pass_str.as_bytes());
+            let _ = std::io::stdout().flush();
             std::process::exit(0);
         }
-        error!("Failed to retrieve password from keyring for alias: {}", alias);
         std::process::exit(1);
     }
 


### PR DESCRIPTION
This pull request refactors the startup and AskPass handling logic in `src/main.rs` to improve clarity and reliability. The main changes are focused on how logging is initialized and how the AskPass password retrieval flow is handled asynchronously.

Improvements to logging and initialization:

* Logging initialization is now skipped when running in AskPass mode (when the `RUSTMIUS_ASKPASS_ALIAS` environment variable is set), preventing unnecessary log output during password retrieval.
* The tracing subscriber now explicitly writes logs to stderr for better separation of logs and program output.

AskPass flow improvements:

* The AskPass password retrieval now uses async/await directly instead of blocking on the runtime, making the code simpler and more idiomatic.
* Password output to stdout is now performed using `write_all` and `flush` to ensure the password is reliably sent to the caller (such as SSH).
* Redundant debug and error logging during AskPass handling has been removed to avoid interfering with the expected output.

fix #146 