### PR TITLE
fix: remove unused imports and dead code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod engines;
 
 use gtk4::prelude::*;
 use crate::ui::window::build_ui;
-use tracing::{debug, info, error};
+use tracing::info;
 
 #[tokio::main]
 async fn main() {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -471,15 +471,6 @@ impl AppWindow {
         });
     }
 
-    fn count_pages_with_prefix(notebook: &gtk4::Notebook, prefix: &str) -> u32 {
-        let mut count = 0;
-        for i in 0..notebook.n_pages() {
-            if let Some(p) = notebook.nth_page(Some(i))
-                && p.widget_name().starts_with(prefix) { count += 1; }
-        }
-        count
-    }
-
     fn get_insert_position(notebook: &gtk4::Notebook) -> u32 {
         for i in 0..notebook.n_pages() {
             if let Some(c) = notebook.nth_page(Some(i))


### PR DESCRIPTION
This pull request contains minor code cleanup and simplification. The main changes are the removal of unused imports and a redundant helper function.

Code cleanup:

* Removed unused `debug` and `error` imports from `tracing` in `src/main.rs`.
* Removed the unused `count_pages_with_prefix` function from the `AppWindow` implementation in `src/ui/window.rs`.