### PR TITLE
ui: align add server button with sidebar icons

### DIFF
--- a/src/ui/components/header.rs
+++ b/src/ui/components/header.rs
@@ -8,8 +8,13 @@ pub struct Header {
 impl Header {
     pub fn new() -> Self {
         let container = gtk4::HeaderBar::new();
+        container.add_css_class("main-headerbar");
+        
         let add_btn = gtk4::Button::from_icon_name("list-add-symbolic");
         add_btn.add_css_class("suggested-action");
+        add_btn.set_margin_start(11);
+        add_btn.set_valign(gtk4::Align::Center);
+        
         container.pack_start(&add_btn);
 
         Self {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -48,6 +48,18 @@ pub fn init_style() {
             padding: 10px;
             transition: all 150ms;
         }
+        .main-headerbar {
+            padding-left: 0;
+            padding-right: 0;
+        }
+        .main-headerbar > box.start {
+            margin: 0;
+            padding: 0;
+        }
+        headerbar box.start {
+            margin-left: 0;
+            padding-left: 0;
+        }
     ");
     gtk4::style_context_add_provider_for_display(
         &gdk::Display::default().expect("Could not connect to a display."),


### PR DESCRIPTION
This pull request makes UI improvements to the header bar in the application. The main changes focus on enhancing the appearance and layout of the header by adjusting CSS classes and margins.

**UI enhancements:**

* Added the `main-headerbar` CSS class to the header bar in `Header` and defined new style rules for it, reducing left and right padding for a cleaner look. [[1]](diffhunk://#diff-6768e5c3cd55dd8d14971f789bbb5e596c918474de836be45270381ea3298008R11-R17) [[2]](diffhunk://#diff-98f5d75e3ef1c7cb38c1d557e9b883919bbd303c95acb623de2441f08abef0dbR51-R62)
* Set the start margin and vertical alignment for the add button (`add_btn`), ensuring better alignment and spacing within the header bar.

**Style adjustments:**

* Updated CSS in `init_style` to remove extra margins and paddings from elements inside the header bar, especially targeting `.main-headerbar > box.start` and `headerbar box.start`, for a more consistent header layout.