### PR TITLE
Support IdentityAgent for SFTP connections (fix #157)

### DIFF
--- a/src/config_observer.rs
+++ b/src/config_observer.rs
@@ -170,6 +170,11 @@ pub struct SshHost {
     pub user: Option<String>,
     pub port: Option<u16>,
     pub identity_file: Option<String>,
+    /// Path to the authentication agent socket (`IdentityAgent` directive),
+    /// e.g. 1Password's `~/.1password/agent.sock`. Honored when falling back
+    /// to agent authentication in the SFTP/SSH engine.
+    #[serde(default)]
+    pub identity_agent: Option<String>,
 }
 
 pub fn get_default_config_path() -> Option<std::path::PathBuf> {
@@ -207,6 +212,10 @@ pub fn refresh_hosts() -> anyhow::Result<Vec<SshHost>> {
 pub fn parse_ssh_config(content: &str) -> Vec<SshHost> {
     let mut hosts = Vec::new();
     let mut current_host: Option<SshHost> = None;
+    // `IdentityAgent` is commonly declared once in a global `Host *` block
+    // (e.g. by 1Password). Track it so it can be applied as a default to any
+    // host that doesn't specify its own.
+    let mut global_identity_agent: Option<String> = None;
 
     for line in content.lines() {
         let line = line.trim();
@@ -238,6 +247,7 @@ pub fn parse_ssh_config(content: &str) -> Vec<SshHost> {
                     user: None,
                     port: None,
                     identity_file: None,
+                    identity_agent: None,
                 });
             }
             "hostname" => {
@@ -261,6 +271,15 @@ pub fn parse_ssh_config(content: &str) -> Vec<SshHost> {
                     host.identity_file = Some(value.to_string());
                 }
             }
+            "identityagent" => {
+                match current_host {
+                    Some(ref mut host) if host.alias != "*" => {
+                        host.identity_agent = Some(value.to_string());
+                    }
+                    // A `Host *` (or pre-host) declaration becomes the global default.
+                    _ => global_identity_agent = Some(value.to_string()),
+                }
+            }
             _ => {}
         }
     }
@@ -269,6 +288,14 @@ pub fn parse_ssh_config(content: &str) -> Vec<SshHost> {
         && !host.alias.is_empty() && !host.hostname.is_empty() {
             hosts.push(host);
         }
+
+    if let Some(ref agent) = global_identity_agent {
+        for host in &mut hosts {
+            if host.identity_agent.is_none() {
+                host.identity_agent = Some(agent.clone());
+            }
+        }
+    }
 
     hosts
 }
@@ -392,6 +419,31 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_ssh_config_with_identity_agent() {
+        let config = "Host my-server\n  HostName 1.2.3.4\n  User root\n  IdentityAgent ~/.1password/agent.sock";
+        let hosts = parse_ssh_config(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].identity_agent, Some("~/.1password/agent.sock".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ssh_config_global_identity_agent_applies_to_hosts() {
+        let config = "Host *\n  IdentityAgent ~/.1password/agent.sock\n\nHost my-server\n  HostName 1.2.3.4\n  User root";
+        let hosts = parse_ssh_config(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].alias, "my-server");
+        assert_eq!(hosts[0].identity_agent, Some("~/.1password/agent.sock".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ssh_config_host_identity_agent_overrides_global() {
+        let config = "Host *\n  IdentityAgent ~/.1password/agent.sock\n\nHost my-server\n  HostName 1.2.3.4\n  IdentityAgent ~/.ssh/custom.sock";
+        let hosts = parse_ssh_config(config);
+        assert_eq!(hosts.len(), 1);
+        assert_eq!(hosts[0].identity_agent, Some("~/.ssh/custom.sock".to_string()));
+    }
+
+    #[test]
     fn test_parse_ssh_config_with_identity_file() {
         let config = "Host my-server\n  HostName 1.2.3.4\n  User root\n  Port 22\n  IdentityFile ~/.ssh/id_ed25519";
         let hosts = parse_ssh_config(config);
@@ -415,6 +467,7 @@ mod tests {
             user: Some("admin".to_string()),
             port: Some(22),
             identity_file: Some("~/.ssh/id_ed25519".to_string()),
+            identity_agent: None,
         };
         let alias_quoted = if host.alias.contains(' ') {
             format!("\"{}\"", host.alias)
@@ -450,6 +503,7 @@ mod tests {
             user: Some("user".to_string()),
             port: Some(22),
             identity_file: Some("/home/user/my keys/id_rsa".to_string()),
+            identity_agent: None,
         };
         let mut entry = format!(
             "\nHost {}\n    HostName {}\n    User {}\n    Port {}\n",

--- a/src/engines/ssh.rs
+++ b/src/engines/ssh.rs
@@ -10,6 +10,24 @@ use tracing::{info, warn, instrument};
 
 type SharedSession = Arc<tokio::sync::Mutex<Option<Session>>>;
 
+/// Restores the previous `SSH_AUTH_SOCK` value when dropped, so temporarily
+/// pointing libssh2 at a host-specific `IdentityAgent` socket doesn't leak.
+struct SshAuthSockGuard {
+    previous: Option<std::ffi::OsString>,
+}
+
+impl Drop for SshAuthSockGuard {
+    fn drop(&mut self) {
+        // SAFETY: runs on the same blocking thread that set the variable.
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("SSH_AUTH_SOCK", value),
+                None => std::env::remove_var("SSH_AUTH_SOCK"),
+            }
+        }
+    }
+}
+
 fn get_ssh_pool() -> &'static Mutex<HashMap<String, SharedSession>> {
     static POOL: OnceLock<Mutex<HashMap<String, SharedSession>>> = OnceLock::new();
     POOL.get_or_init(|| Mutex::new(HashMap::new()))
@@ -99,6 +117,21 @@ pub async fn establish_ssh_session(host: &SshHost, password: Option<&str>) -> an
         }
 
         if !authenticated {
+            // libssh2 (via the ssh2 crate) only discovers the agent socket
+            // through `SSH_AUTH_SOCK`. When the host declares an `IdentityAgent`
+            // in the SSH config (e.g. 1Password's `~/.1password/agent.sock`),
+            // point the agent at that socket so it behaves like the system
+            // `ssh` client used by the terminal.
+            let _agent_sock_guard = host_cloned.identity_agent.as_deref().map(|agent_path| {
+                let expanded = expand_tilde(agent_path);
+                let previous = std::env::var_os("SSH_AUTH_SOCK");
+                tracing::trace!("Using IdentityAgent socket: {}", expanded.display());
+                // SAFETY: SSH auth runs serially within this blocking task and
+                // the previous value is restored when the guard drops.
+                unsafe { std::env::set_var("SSH_AUTH_SOCK", &expanded); }
+                SshAuthSockGuard { previous }
+            });
+
             tracing::trace!("Trying agent authentication");
             if sess.userauth_agent(user).is_ok() {
                 info!("Authenticated via SSH agent");

--- a/src/ui/add_server_dialog.rs
+++ b/src/ui/add_server_dialog.rs
@@ -118,6 +118,7 @@ where F: Fn(SshHost, String) + 'static
                 user: Some(user_entry.text().to_string().trim().to_string()).filter(|s| !s.is_empty()),
                 port: port_entry.text().to_string().trim().parse::<u16>().ok(),
                 identity_file,
+                identity_agent: None,
             };
             let password = pass_entry.text().to_string();
             if !host.alias.is_empty() && !host.hostname.is_empty() {


### PR DESCRIPTION
## Summary

Fix SFTP authentication failures for users with SSH keys stored in 1Password or other SSH agents that use `IdentityAgent` in their SSH config.

## Problem

When a user has their SSH key stored in 1Password (or similar SSH agent) configured via `IdentityAgent ~/.1password/agent.sock` in their SSH config:
- **SSH terminal connections work** — the system `ssh` client honors the `IdentityAgent` directive
- **SFTP connections fail** — libssh2 (used by the SFTP engine) only discovers agents via `SSH_AUTH_SOCK`

This resulted in the error: "Agent auth failed or no agent running" even though SSH worked fine (issue #157).

## Solution

1. **Parse `IdentityAgent` from SSH config**
   - Extract per-host `IdentityAgent` directives
   - Support global `Host *` block declarations (standard 1Password placement)
   - Per-host settings override global defaults

2. **Point libssh2 at custom agent sockets**
   - Before agent authentication, temporarily set `SSH_AUTH_SOCK` to the host's configured `IdentityAgent` path
   - Use RAII guard to restore previous value after auth
   - Makes libssh2 behavior consistent with system `ssh` client

3. **Add test coverage**
   - Test per-host `IdentityAgent` parsing
   - Test global `Host *` block declarations
   - Test per-host override of global setting

## Changes

- `src/config_observer.rs`: Added `identity_agent` field to `SshHost`, updated parser to handle `IdentityAgent` directive with proper scoping
- `src/engines/ssh.rs`: Implement `SshAuthSockGuard` RAII guard, use it to temporarily point libssh2 at custom agent socket
- `src/ui/add_server_dialog.rs`: Initialize new field in manual host creation

## Testing

```bash
cargo build    # ✓ Compiles without warnings
cargo test     # ✓ All tests pass (including 3 new agent parsing tests)
```