### PR TITLE
feat(packaging): build a Debian/Ubuntu .deb and attach it to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,26 +110,73 @@ jobs:
           name: binary-${{ matrix.suffix }}
           path: target/${{ matrix.target }}/release/rustmius-${{ matrix.suffix }}
 
+  deb:
+    name: Build .deb (Debian/Ubuntu)
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Install packaging dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-4-dev libvte-2.91-gtk4-dev dpkg-dev imagemagick
+
+      - name: Download prebuilt generic binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-x86_64
+          path: prebuilt
+
+      - name: Stage binary for packaging
+        run: |
+          mkdir -p target/release
+          install -m755 prebuilt/rustmius-x86_64 target/release/rustmius
+
+      - name: Build .deb package
+        env:
+          SKIP_BUILD: "1"
+        run: ./packages/deb/build-deb.sh
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deb
+          path: dist/*.deb
+
   release:
     name: Create Release
-    needs: [prepare, build]
+    needs: [prepare, build, deb]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Download Artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: binary-*
           merge-multiple: true
 
+      - name: Download .deb artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: deb
+          path: artifacts
+
       - name: Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.new_version }}
           target_commitish: ${{ needs.prepare.outputs.sha }}
-          files: artifacts/rustmius-*
+          files: |
+            artifacts/rustmius-*
+            artifacts/*.deb
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 /target
 .idea/
+
+# Packaging build artifacts
+/dist
+packages/**/pkg/
+packages/**/src/
+packages/**/*.tar.gz
+packages/**/*.tar.zst
+packages/**/*.pkg.tar.*

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ The easiest way on Arch Linux is to use the `-bin` package (pre-compiled and opt
 yay -S rustmius-bin
 ```
 
+### Debian / Ubuntu (.deb)
+Download the `.deb` from the [Releases](https://github.com/Cleboost/Rustmius/releases) page and install it (this pulls in the required GTK4/VTE libraries automatically):
+```bash
+sudo apt install ./rustmius_<version>_amd64.deb
+```
+> Built against GTK4 ≥ 4.12, so it targets Ubuntu 24.04+ and Debian 13+. On older releases, build from source instead. You can also build the package yourself with `packages/deb/build-deb.sh`.
+
 ### Other Distributions (Binaries)
 Download the binary matching your hardware from the [Releases](https://github.com/Cleboost/Rustmius/releases) page:
 - `rustmius-x86_64`: For standard 64-bit Linux PCs.

--- a/packages/deb/build-deb.sh
+++ b/packages/deb/build-deb.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Build a .deb package for Rustmius (Debian / Ubuntu).
+#
+# Usage:
+#   packages/deb/build-deb.sh            # builds release binary if missing, then packages
+#   SKIP_BUILD=1 packages/deb/build-deb.sh   # reuse an existing target/release/rustmius
+#
+# Output: dist/rustmius_<version>_<arch>.deb (in the repo root)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PKG_NAME="rustmius"
+VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+MAINTAINER="${DEB_MAINTAINER:-Clement Balarot <clement.balarot@gmail.com>}"
+DEB_ARCH="$(dpkg --print-architecture)"
+
+echo ">> Packaging $PKG_NAME $VERSION for $DEB_ARCH"
+
+# Build the release binary.
+BIN="target/release/$PKG_NAME"
+if [[ "${SKIP_BUILD:-0}" != "1" || ! -x "$BIN" ]]; then
+    echo ">> Building release binary (fat LTO, this can take a while)..."
+    cargo build --release --locked
+fi
+[[ -x "$BIN" ]] || { echo "!! Binary not found at $BIN" >&2; exit 1; }
+
+# Assemble the package tree.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+chmod 755 "$STAGE"
+
+install -Dm755 "$BIN" "$STAGE/usr/bin/$PKG_NAME"
+install -Dm644 "packages/org.rustmius.Rustmius.desktop" \
+    "$STAGE/usr/share/applications/org.rustmius.Rustmius.desktop"
+
+# Icon: resize to 512x512 when ImageMagick is available, else keep the source
+# 500x500 in a size-matched hicolor dir.
+ICON_SRC="packages/rustmius.png"
+if command -v convert >/dev/null 2>&1; then
+    install -dm755 "$STAGE/usr/share/icons/hicolor/512x512/apps"
+    convert "$ICON_SRC" -resize 512x512 \
+        "$STAGE/usr/share/icons/hicolor/512x512/apps/$PKG_NAME.png"
+elif command -v magick >/dev/null 2>&1; then
+    install -dm755 "$STAGE/usr/share/icons/hicolor/512x512/apps"
+    magick "$ICON_SRC" -resize 512x512 \
+        "$STAGE/usr/share/icons/hicolor/512x512/apps/$PKG_NAME.png"
+else
+    install -Dm644 "$ICON_SRC" \
+        "$STAGE/usr/share/icons/hicolor/500x500/apps/$PKG_NAME.png"
+fi
+
+find "$STAGE/usr/share/icons" -type f -name '*.png' -exec chmod 644 {} +
+
+# Man page (version stamped in from Cargo.toml).
+install -dm755 "$STAGE/usr/share/man/man1"
+sed "s/@VERSION@/$VERSION/g" "packages/deb/rustmius.1" \
+    > "$STAGE/usr/share/man/man1/$PKG_NAME.1"
+chmod 644 "$STAGE/usr/share/man/man1/$PKG_NAME.1"
+gzip -9n "$STAGE/usr/share/man/man1/$PKG_NAME.1"
+
+# Copyright file + compressed changelog under /usr/share/doc (Debian policy).
+# Native package, so the changelog is named "changelog.gz".
+install -Dm644 "packages/deb/copyright" "$STAGE/usr/share/doc/$PKG_NAME/copyright"
+CHANGELOG="$STAGE/usr/share/doc/$PKG_NAME/changelog"
+cat > "$CHANGELOG" <<EOF
+rustmius ($VERSION) unstable; urgency=medium
+
+  * Release $VERSION. See the GitHub release notes for details:
+    https://github.com/Cleboost/Rustmius/releases/tag/v$VERSION
+
+ -- $MAINTAINER  $(date -R)
+EOF
+chmod 644 "$CHANGELOG"
+gzip -9n "$CHANGELOG"
+
+# Compute dependencies from the actual binary via dpkg-shlibdeps.
+DEPENDS=""
+if command -v dpkg-shlibdeps >/dev/null 2>&1; then
+    echo ">> Resolving shared-library dependencies..."
+    SHLIB_DIR="$(mktemp -d)"
+    mkdir -p "$SHLIB_DIR/debian"
+    touch "$SHLIB_DIR/debian/control"
+    ( cd "$SHLIB_DIR" && dpkg-shlibdeps -O "$REPO_ROOT/$BIN" 2>/dev/null ) \
+        > "$SHLIB_DIR/out" || true
+    DEPENDS="$(sed -E 's/^shlibs:Depends=//' "$SHLIB_DIR/out" | head -n1)"
+    rm -rf "$SHLIB_DIR"
+fi
+# Fallback if shlibdeps is unavailable.
+if [[ -z "$DEPENDS" ]]; then
+    DEPENDS="libc6, libgtk-4-1 (>= 4.6), libvte-2.91-gtk4-0, libssl3"
+fi
+echo ">> Depends: $DEPENDS"
+
+# Control file.
+INSTALLED_SIZE="$(du -k -s "$STAGE" | cut -f1)"
+mkdir -p "$STAGE/DEBIAN"
+
+cat > "$STAGE/DEBIAN/control" <<EOF
+Package: $PKG_NAME
+Version: $VERSION
+Architecture: $DEB_ARCH
+Maintainer: $MAINTAINER
+Installed-Size: $INSTALLED_SIZE
+Depends: $DEPENDS
+Section: net
+Priority: optional
+Homepage: https://github.com/Cleboost/Rustmius
+Description: Local Termius alternative for Linux (GTK4)
+ Rustmius is a modern, fast, and fully local alternative to Termius,
+ built with Rust and GTK4. It provides an integrated SSH terminal
+ (via VTE), an advanced SFTP explorer with drag & drop, a host
+ manager, and secure secret storage through the system keyring.
+EOF
+
+# Maintainer scripts: refresh icon + desktop caches.
+cat > "$STAGE/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+if [ "$1" = "configure" ]; then
+    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+        gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor || true
+    fi
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database -q /usr/share/applications || true
+    fi
+fi
+EOF
+cat > "$STAGE/DEBIAN/postrm" <<'EOF'
+#!/bin/sh
+set -e
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+        gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor || true
+    fi
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database -q /usr/share/applications || true
+    fi
+fi
+EOF
+chmod 755 "$STAGE/DEBIAN/postinst" "$STAGE/DEBIAN/postrm"
+
+# Build the .deb.
+mkdir -p dist
+OUT="dist/${PKG_NAME}_${VERSION}_${DEB_ARCH}.deb"
+dpkg-deb --root-owner-group --build "$STAGE" "$OUT"
+
+echo ""
+echo ">> Built: $OUT"
+dpkg-deb --info "$OUT"
+echo ">> Contents:"
+dpkg-deb --contents "$OUT"

--- a/packages/deb/copyright
+++ b/packages/deb/copyright
@@ -1,0 +1,30 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Rustmius
+Upstream-Contact: Cleboost
+Source: https://github.com/Cleboost/Rustmius
+
+Files: *
+Copyright: 2024-2026 Clement Balarot and the Rustmius contributors
+License: AGPL-3.0-or-later
+
+Files: packages/deb/*
+Copyright: 2026 Subhan Gadirli <subhanqedirli@protonmail.com>
+License: AGPL-3.0-or-later
+Comment: Debian/Ubuntu packaging.
+
+License: AGPL-3.0-or-later
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published
+ by the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+ .
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the full text of the GNU Affero General Public
+ License version 3 can be found in "/usr/share/common-licenses/AGPL-3".

--- a/packages/deb/rustmius.1
+++ b/packages/deb/rustmius.1
@@ -1,0 +1,25 @@
+.TH RUSTMIUS 1 "2026" "rustmius @VERSION@" "User Commands"
+.SH NAME
+rustmius \- local Termius alternative for Linux (GTK4)
+.SH SYNOPSIS
+.B rustmius
+.SH DESCRIPTION
+.B Rustmius
+is a modern, fast, and fully local alternative to Termius, built with Rust
+and GTK4. It provides an integrated SSH terminal (via VTE), an advanced SFTP
+explorer with drag & drop, a host manager, and secure secret storage through
+the system keyring.
+.PP
+Rustmius is a graphical application and takes no command-line arguments; run
+it from your application launcher or from a terminal.
+.SH ENVIRONMENT
+.TP
+.B RUST_LOG
+Controls log verbosity (e.g. \fBinfo\fR, \fBdebug\fR) via tracing-subscriber.
+.SH FILES
+Configuration and secrets are stored locally in the user's standard
+configuration directory and the system keyring.
+.SH HOMEPAGE
+https://github.com/Cleboost/Rustmius
+.SH AUTHOR
+Cleboost and the Rustmius contributors.


### PR DESCRIPTION
Add packages/deb/build-deb.sh, which assembles a policy-compliant .deb (control, copyright, generated changelog, man page, icon, desktop entry, postinst/postrm cache hooks) with dependencies resolved from the built binary via dpkg-shlibdeps. Passes lintian with no warnings.

Wire it into the release workflow: a new 'deb' job repackages the already-built generic binary and uploads it, and the release job now attaches the .deb to the GitHub release assets. Document the install path in the README and ignore the /dist build output.